### PR TITLE
Fix getter methods for optional fields

### DIFF
--- a/ProtoGen/csharp.xslt
+++ b/ProtoGen/csharp.xslt
@@ -425,7 +425,7 @@ namespace <xsl:value-of select="translate($namespace,':-/\','__..')"/>
       </xsl:call-template></xsl:variable>
     public <xsl:value-of select="concat($fieldType,' ',$name)"/>
     {
-      get { return <xsl:value-of select="$field"/> <xsl:if test="$specified">?? <xsl:value-of select="$defaultValue"/></xsl:if>; }
+      get { return <xsl:value-of select="$field"/>; }
       set { <xsl:if test="$optionPartialMethods">On<xsl:value-of select="$nameNoKeyword"/>Changing(value); </xsl:if><xsl:if test="$optionPreObservable">OnPropertyChanging(@"<xsl:value-of select="$nameNoKeyword"/>"); </xsl:if><xsl:value-of select="$field"/> = value; <xsl:if test="$optionObservable">OnPropertyChanged(@"<xsl:value-of select="$nameNoKeyword"/>"); </xsl:if><xsl:if test="$optionPartialMethods">On<xsl:value-of select="$nameNoKeyword"/>Changed();</xsl:if>}
     }<xsl:if test="$optionPartialMethods">
     partial void On<xsl:value-of select="$nameNoKeyword"/>Changing(<xsl:value-of select="$propType"/> value);

--- a/ProtoGen/csharp.xslt
+++ b/ProtoGen/csharp.xslt
@@ -423,7 +423,7 @@ namespace <xsl:value-of select="translate($namespace,':-/\','__..')"/>
       <xsl:call-template name="stripKeyword">
         <xsl:with-param name="value" select="$name"/>
       </xsl:call-template></xsl:variable>
-    public <xsl:value-of select="concat($propType,' ',$name)"/>
+    public <xsl:value-of select="concat($fieldType,' ',$name)"/>
     {
       get { return <xsl:value-of select="$field"/> <xsl:if test="$specified">?? <xsl:value-of select="$defaultValue"/></xsl:if>; }
       set { <xsl:if test="$optionPartialMethods">On<xsl:value-of select="$nameNoKeyword"/>Changing(value); </xsl:if><xsl:if test="$optionPreObservable">OnPropertyChanging(@"<xsl:value-of select="$nameNoKeyword"/>"); </xsl:if><xsl:value-of select="$field"/> = value; <xsl:if test="$optionObservable">OnPropertyChanged(@"<xsl:value-of select="$nameNoKeyword"/>"); </xsl:if><xsl:if test="$optionPartialMethods">On<xsl:value-of select="$nameNoKeyword"/>Changed();</xsl:if>}


### PR DESCRIPTION
Optional fields are supported. However, in generated code their getter methods will not return `null` in case when those fields are not specified.

To fix this, return type of getter is set to be `$fieldType` (which, unlike $propType, does contain `?` at the end for optional fields), and original value (specified or not) is returned as is.