### PR TITLE
It only makes sense to have default values for optional fields

### DIFF
--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -1812,7 +1812,8 @@ namespace ProtoBuf.Meta
                     string schemaTypeName = member.GetSchemaTypeName(true, ref requiresBclImport);
                     builder.Append(schemaTypeName).Append(" ")
                          .Append(member.Name).Append(" = ").Append(member.FieldNumber);
-                    if(member.DefaultValue != null)
+
+                    if(member.DefaultValue != null && member.IsRequired == false)
                     {
                         if (member.DefaultValue is string)
                         {


### PR DESCRIPTION
Hi Marc,

I've been testing serialisation between .NET and Java with .proto files and think that by only adding default values when a member is not marked as required would make sense.  (When it's required, there'll always be a value, so adding a default one seems redundant).

What do you think?


Cheers,

Rob