### PR TITLE
Updating proto dll version for WcfTest and WcfClient sample project

### DIFF
--- a/TestWcfClient/app.config
+++ b/TestWcfClient/app.config
@@ -43,7 +43,7 @@
       </behaviors>
       <extensions>
         <behaviorExtensions>
-          <add name="protobuf" type="ProtoBuf.ServiceModel.ProtoBehaviorExtension, protobuf-net, Version=1.0.0.275, Culture=neutral, PublicKeyToken=257b51d87d2e4d67"/>
+          <add name="protobuf" type="ProtoBuf.ServiceModel.ProtoBehaviorExtension, protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67"/>
         </behaviorExtensions>
       </extensions>
     </system.serviceModel>


### PR DESCRIPTION
Hi Marc,

I tried to create a sample solution with WcfTestDto, WcfTestClient and server. I created empty projects to better understand the structure and pulled the protobuf dll from nuget. Adding back the config and code files one by one caused an issue where the problem seems to be the reference to the 1.0.0275 in the app.config. Updating it to 2.0.0.688 solved my problem. 

Please, consider if this change make sense in the master.

Thanks,
Krisztian 
