### PR TITLE
Made some fixes to problems using protobuf-net portable from a UWP

### DIFF
--- a/protobuf-net/Helpers.cs
+++ b/protobuf-net/Helpers.cs
@@ -337,6 +337,10 @@ namespace ProtoBuf
             if (type == typeof(TimeSpan)) return ProtoTypeCode.TimeSpan;
             if (type == typeof(Guid)) return ProtoTypeCode.Guid;
             if (type == typeof(Uri)) return ProtoTypeCode.Uri;
+#if PORTABLE
+            // In PCLs, the Uri type may not match (WinRT uses Internal/Uri, .Net uses System/Uri), so match on the full name instead
+            if (type.FullName == typeof(Uri).FullName) return ProtoTypeCode.Uri;
+#endif
             if (type == typeof(byte[])) return ProtoTypeCode.ByteArray;
             if (type == typeof(System.Type)) return ProtoTypeCode.Type;
 

--- a/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1716,7 +1716,7 @@ namespace ProtoBuf.Meta
             const string message = "Timeout while inspecting metadata; this may indicate a deadlock. This can often be avoided by preparing necessary serializers during application initialization, rather than allowing multiple threads to perform the initial metadata inspection; please also see the LockContended event";
             opaqueToken = 0;
 #if PORTABLE
-            if(!Monitor.TryEnter(types)) throw new TimeoutException(message); // yes, we have to do this immediately - I'm not creating a "hot" loop, just because Sleep() doesn't exist...
+            if(!Monitor.TryEnter(types, metadataTimeoutMilliseconds)) throw new TimeoutException(message);
             opaqueToken = Interlocked.CompareExchange(ref contentionCounter, 0, 0); // just fetch current value (starts at 1)
 #elif CF2 || CF35
             int remaining = metadataTimeoutMilliseconds;

--- a/protobuf-net/Meta/ValueMember.cs
+++ b/protobuf-net/Meta/ValueMember.cs
@@ -367,6 +367,13 @@ namespace ProtoBuf.Meta
                 {
                     ser = new UriDecorator(model, ser);
                 }
+#if PORTABLE
+                else if(memberType.FullName == typeof(Uri).FullName)
+                {
+                    // In PCLs, the Uri type may not match (WinRT uses Internal/Uri, .Net uses System/Uri)
+                    ser = new ReflectedUriDecorator(memberType, model, ser);
+                }
+#endif
                 if (member != null)
                 {
                     PropertyInfo prop = member as PropertyInfo;
@@ -502,7 +509,7 @@ namespace ProtoBuf.Meta
                     return new GuidSerializer(model);
                 case ProtoTypeCode.Uri:
                     defaultWireType = WireType.String;
-                    return new StringSerializer(model); // treat as string; wrapped in decorator later
+                    return new StringSerializer(model);
                 case ProtoTypeCode.ByteArray:
                     defaultWireType = WireType.String;
                     return new BlobSerializer(model, overwriteList);

--- a/protobuf-net/Serializers/ReflectedUriDecorator.cs
+++ b/protobuf-net/Serializers/ReflectedUriDecorator.cs
@@ -1,0 +1,69 @@
+﻿#if !NO_RUNTIME
+#if PORTABLE
+using System;
+using System.Reflection;
+
+namespace ProtoBuf.Serializers
+{
+    /// <summary>
+    /// Manipulates with uris via reflection rather than strongly typed objects.
+    /// This is because in PCLs, the Uri type may not match (WinRT uses Internal/Uri, .Net uses System/Uri)
+    /// </summary>
+    sealed class ReflectedUriDecorator : ProtoDecoratorBase
+    {
+        private readonly Type expectedType;
+
+        private readonly PropertyInfo absoluteUriProperty;
+
+        private readonly ConstructorInfo typeConstructor;
+
+        public ReflectedUriDecorator(Type type, ProtoBuf.Meta.TypeModel model, IProtoSerializer tail) : base(tail)
+        {
+            expectedType = type;
+
+            absoluteUriProperty = expectedType.GetProperty("AbsoluteUri");
+            typeConstructor = expectedType.GetConstructor(new Type[] { typeof(string) });
+        }
+        public override Type ExpectedType { get { return expectedType; } }
+        public override bool RequiresOldValue { get { return false; } }
+        public override bool ReturnsValue { get { return true; } }
+        
+        public override void Write(object value, ProtoWriter dest)
+        {
+            Tail.Write(absoluteUriProperty.GetValue(value, null), dest);
+        }
+        public override object Read(object value, ProtoReader source)
+        {
+            Helpers.DebugAssert(value == null); // not expecting incoming
+            string s = (string)Tail.Read(null, source);
+
+            return s.Length == 0 ? null : typeConstructor.Invoke(new object[] { s });
+        }
+
+#if FEAT_COMPILER
+        protected override void EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {
+            ctx.LoadValue(valueFrom);
+            ctx.LoadValue(absoluteUriProperty);
+            Tail.EmitWrite(ctx, null);
+        }
+        protected override void EmitRead(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {
+            Tail.EmitRead(ctx, valueFrom);
+            ctx.CopyValue();
+            Compiler.CodeLabel @nonEmpty = ctx.DefineLabel(), @end = ctx.DefineLabel();
+            ctx.LoadValue(typeof(string).GetProperty("Length"));
+            ctx.BranchIfTrue(@nonEmpty, true);
+            ctx.DiscardValue();
+            ctx.LoadNullRef();
+            ctx.Branch(@end, true);
+            ctx.MarkLabel(@nonEmpty);
+            ctx.EmitCtor(expectedType, ctx.MapType(typeof(string)));
+            ctx.MarkLabel(@end);
+            
+        }
+#endif 
+    }
+}
+#endif
+#endif

--- a/protobuf-net/protobuf-net.csproj
+++ b/protobuf-net/protobuf-net.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Serializers\MemberSpecifiedDecorator.cs" />
     <Compile Include="Serializers\SystemTypeSerializer.cs" />
     <Compile Include="Serializers\TupleSerializer.cs" />
+    <Compile Include="Serializers\ReflectedUriDecorator.cs" />
     <Compile Include="Serializers\UriDecorator.cs" />
     <Compile Include="Serializers\EnumSerializer.cs" />
     <Compile Include="Serializers\DefaultValueDecorator.cs" />


### PR DESCRIPTION
In universal windows platform the Uri type comes from Internal/Uri, but in a PCL the Uri type used is from System/Uri. The types are not interchangeable. Although the types are different and come from different assemblies, they both the have the same full name of System.Uri. This PR changes the type checks for URI to use .FullName and then uses the new ReflectedUriDecorator in the case of a match.

The ReflectedUriDecorator uses reflection to call the AbsoluteUri and the constructor of the URI type that is being serialized/deserialized as this ensures that the matching type is used and not the PCL System/Uri type.

I also added the metadataTimeoutMilliseconds value for the portable build. I think this is a recent addition to Monitor.TryEnter in PCLs and it prevents the timeout exception happening so frequently.