### PR TITLE
TupleSerializer fails for Turkish regional settings

### DIFF
--- a/protobuf-net.unittest/Issues/TurkishL.cs
+++ b/protobuf-net.unittest/Issues/TurkishL.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using System.Threading;
+using NUnit.Framework;
+
+namespace ProtoBuf.unittest.Attribs
+{
+    [TestFixture]
+    public class TurkishL
+    {
+        [Test]
+        public void FakeTupleTest()
+        {
+            //Turkish culture has unusual case-sensitivity rules:  http://blog.codinghorror.com/whats-wrong-with-turkey/
+            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("tr-TR");
+            
+            byte[] ser;
+            using (var ms = new MemoryStream())
+            {
+                var t = new ForTupleSerializer(123, "abc");
+                Serializer.Serialize(ms, t);
+                ser = ms.ToArray();
+            }
+        }
+
+        public class ForTupleSerializer
+        {
+            public ForTupleSerializer(int id, string name)
+            {
+                Id = id;
+                Name = name;
+            }
+
+            public int Id { get; private set; }
+            public string Name { get; private set; }
+        }
+    }
+}

--- a/protobuf-net.unittest/protobuf-net.unittest.csproj
+++ b/protobuf-net.unittest/protobuf-net.unittest.csproj
@@ -18,6 +18,7 @@
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation />
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -118,6 +119,7 @@
     <Compile Include="Attribs\ComplexMultiTypes.cs" />
     <Compile Include="Attribs\PointStruct.cs" />
     <Compile Include="FX11.cs" />
+    <Compile Include="Issues\TurkishL.cs" />
     <Compile Include="Issues\SO8933251.cs" />
     <Compile Include="Meta\Basic.cs" />
     <Compile Include="Meta\Callbacks.cs" />

--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -884,10 +884,9 @@ namespace ProtoBuf.Meta
 
                 for(int j = 0 ; j < parameters.Length ; j++)
                 {
-                    string lower = parameters[j].Name.ToLower();
                     for(int k = 0 ; k < members.Length ; k++)
                     {
-                        if (members[k].Name.ToLower() != lower) continue;
+                        if (string.Compare(parameters[j].Name, members[k].Name, StringComparison.OrdinalIgnoreCase) != 0) continue;
                         Type memberType = Helpers.GetMemberType(members[k]);
                         if (memberType != parameters[j].ParameterType) continue;
 


### PR DESCRIPTION
Hi Marc,

Thanks for your fantastic work in writing and supporting Protobuf.net.  We ran into an issue in production where serialization would fail for users running under Turkish regional settings.  I found out that this was due to TupleSerializer not being used properly when doing case-invariant string comparisons.  Specifically, the string "Id".ToLower() != "id".ToLower() under Turkish regional settings.  Ref:  http://blog.codinghorror.com/whats-wrong-with-turkey/

Included are a suggested unit test and fix.  The fix uses OrdinalIgnoreCase; unsure if this would break any of your users' code (if the code is written in another language such that special rules for case sensitivity beyond OrdinalIgnoreCase are required), but it seems clear that the case sensitivity should depend only on the code, not on the runtime culture, otherwise all of your users may be affected depending on THEIR users' regional settings.

thanks!
-Stephen