### PR TITLE
handle empty bytes in some cases

### DIFF
--- a/protobuf-net/ProtoReader.cs
+++ b/protobuf-net/ProtoReader.cs
@@ -659,7 +659,7 @@ namespace ProtoBuf
             // then be called)
             if (blockEnd <= position || wireType == WireType.EndGroup) { return 0; }
             uint tag;
-            if (TryReadUInt32Variant(out tag))
+            if (TryReadUInt32Variant(out tag) && tag != 0)
             {
                 wireType = (WireType)(tag & 7);
                 fieldNumber = (int)(tag >> 3);
@@ -928,6 +928,8 @@ namespace ProtoBuf
                         reader.available -= len;
                     }
                     return value;
+                case WireType.Variant:
+                    return new byte[0];
                 default:
                     throw reader.CreateWireTypeException();
             }


### PR DESCRIPTION
We get some messages from java which don't have set some `optional bytes` fields and protobuf-net library cannot read them. This fix help us to read these messages.