### PR TITLE
Added check for list handling on nested lists.

### DIFF
--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -1454,12 +1454,22 @@ namespace ProtoBuf.Meta
             // check for nested data (not allowed)
             if (itemType != null)
             {
-                Type nestedItemType = null, nestedDefaultType = null;
-                ResolveListTypes(model, itemType, ref nestedItemType, ref nestedDefaultType);
-                if (nestedItemType != null)
+                bool shouldIgnoreListHandling = false;
+                foreach (ProtoContractAttribute protoContractAttribute in itemType.GetCustomAttributes(typeof(ProtoContractAttribute), false))
                 {
-                    throw TypeModel.CreateNestedListsNotSupported();
+                    shouldIgnoreListHandling = protoContractAttribute.IgnoreListHandling;
                 }
+
+                if (!shouldIgnoreListHandling)
+                {
+                    Type nestedItemType = null, nestedDefaultType = null;
+                    ResolveListTypes(model, itemType, ref nestedItemType, ref nestedDefaultType);
+                    if (nestedItemType != null)
+                    {
+                        throw TypeModel.CreateNestedListsNotSupported();
+                    }
+                }
+                
             }
 
             if (itemType != null && defaultType == null)


### PR DESCRIPTION
Fix for https://github.com/mgravell/protobuf-net/issues/9

A list of lists cannot be serialized as Protocol Buffers does not support this. However, it is possible to work around this by using a list of nested objects that in turn contains a list.

If the nested objects match one of the conditions of being a list (e.g. implementing IEnumerable and having an Add method, or implementing IList) then protobuf-net obviously assumes this is a case of jagged nested lists.

However, this is not necessarily how it gets serialized or deserialized if the ProtoContract attribute is applied and has the IgnoreListHandling flag set to true.

Solution is to check for the presence of the ProtoContractAttribute and the flag before throwing the NotSupportedException in question.
