### PR TITLE
Fixed not suppoted error message

### DIFF
--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -1444,7 +1444,7 @@ namespace ProtoBuf.Meta
             {
                 if (type.GetArrayRank() != 1)
                 {
-                    throw new NotSupportedException("Multi-dimension arrays are supported");
+                    throw new NotSupportedException("Multi-dimensional arrays are not supported");
                 }
                 itemType = type.GetElementType();
                 if (itemType == model.MapType(typeof(byte)))


### PR DESCRIPTION
Error message falsely suggested that multi-dimensoal arrays are supported when the error is actually supposed to say they aren't supported