### PR TITLE
Fixed a memory leak in deserialization.

### DIFF
--- a/protobuf-net/ProtoReader.cs
+++ b/protobuf-net/ProtoReader.cs
@@ -119,7 +119,11 @@ namespace ProtoBuf
             source = null;
             model = null;
             BufferPool.ReleaseBufferToPool(ref ioBuffer);
-            if(stringInterner != null) stringInterner.Clear();
+            if (stringInterner != null)
+            {
+                stringInterner.Clear();
+                stringInterner = null;
+            }
             if(netCache != null) netCache.Clear();
         }
         internal int TryReadUInt32VariantWithoutMoving(bool trimNegative, out uint value)
@@ -459,7 +463,7 @@ namespace ProtoBuf
         }
 #else
         private System.Collections.Generic.Dictionary<string,string> stringInterner;
-                private string Intern(string value)
+        private string Intern(string value)
         {
             if (value == null) return null;
             if (value.Length == 0) return "";


### PR DESCRIPTION
The "leak" was caused by the Dictionary used for string caching (to reuse the same string reference if repeated instead of creating a new one). When disposing the ProtoReader, this cache is cleared. However clearing does not dispose all the internal data in the Dictionary, keeping the internal ?hastable? with the size it had. While this is good if the dictionary is to be reused (by, say, deserializing another object of similar characteristics), in our application with several million strings this led to about 80MB being wasted.

The fix simply sets the dictionary to null so it can be collected and will be auto-recreated in subsequent deserializations as needed. I think this is the correct bahavior, but maybe you intended to leave the Dictionary capacity intact, so I submit for your consideration. 
