### PR TITLE
Improve type inheritance error message

### DIFF
--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -139,7 +139,7 @@ namespace ProtoBuf.Meta
         {
             if (baseType == null) throw new ArgumentNullException("baseType");
             if (this.baseType == baseType) return;
-            if (this.baseType != null) throw new InvalidOperationException("A type can only participate in one inheritance hierarchy");
+            if (this.baseType != null) throw new InvalidOperationException(string.Format("Type {0} can only participate in one inheritance hierarchy", this.baseType.Type.FullName));
 
             MetaType type = baseType;
             while (type != null)


### PR DESCRIPTION
This makes debugging multiple inheritance problems a little easier if you are using the nuget assemblies (otherwise there's no hint as to which type is causing the problem.
