### PR TITLE
Fix to compilation issues

### DIFF
--- a/protobuf-net/project.json
+++ b/protobuf-net/project.json
@@ -32,6 +32,18 @@
         "System.Xml": "2.0.0.0"
       }
     },
+	"net30": {
+      "buildOptions": {
+        "allowUnsafe": true,
+        "define": [ "FEAT_COMPILER", "PLAT_BINARYFORMATTER", "PLAT_XMLSERIALIZER", "FEAT_SERVICEMODEL" ]
+      },
+      "frameworkAssemblies": {
+        "System.Xml": "2.0.0.0",
+        "System.ServiceModel": "3.0.0.0",
+        "System.Configuration": "2.0.0.0",
+        "System.Runtime.Serialization": "3.0.0.0"
+      }
+    },
     "net35": {
       "buildOptions": {
         "allowUnsafe": true,

--- a/protobuf-net/protobuf-net.csproj
+++ b/protobuf-net/protobuf-net.csproj
@@ -36,6 +36,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <CopyNuGetImplementations>false</CopyNuGetImplementations>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' != 'Profile'">
@@ -52,7 +53,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Debug\protobuf-net.xml</DocumentationFile>
     <UseVSHostingProcess>false</UseVSHostingProcess>
-    <LangVersion>ISO-2</LangVersion>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -67,7 +67,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>ISO-2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Net20|AnyCPU' ">
     <OutputPath>bin\Net20\</OutputPath>
@@ -120,7 +119,6 @@
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
     <UseVSHostingProcess>false</UseVSHostingProcess>
-    <LangVersion>ISO-2</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
@@ -161,7 +159,6 @@
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
     <UseVSHostingProcess>false</UseVSHostingProcess>
-    <LangVersion>ISO-2</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>


### PR DESCRIPTION
This fixes the fresh pull compilation error.  Adding NET30 to project.json allows protobuf.net to be compiled under .NET 3.0.  
Removing LangVersion from protobuf-net.csproj enables the newer C# language features that have been used.  (Some of the language features being used are as recent as C# 6, so ISO-2 doesn't contain them.  Removing the specified language seems to fix this).

This should fix the problems in #193 , but the main question I have is how other people have been able to compile locally without this problem.  Is there a specific environment setup required to build protobuf-net without these issues?