### PR TITLE
use InliningDiagnoser to find out why given benchmark is slower

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -5,5 +5,6 @@
     <add key="dotnet.myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" protocolVersion="3" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="BenchmarkDotNet" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />    
   </packageSources>
 </configuration>

--- a/src/TheAwaitingGame/Program.cs
+++ b/src/TheAwaitingGame/Program.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Attributes;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using MemoryDiagnoser = BenchmarkDotNet.Diagnosers.MemoryDiagnoser;
 
 namespace TheAwaitingGame
 {
@@ -10,11 +14,27 @@ namespace TheAwaitingGame
     {
         static void Main()
         {
-            var summary = BenchmarkRunner.Run<Benchmarker>();
+            // tell BenchmarkDotNet not to force GC.Collect after benchmark iteration 
+            // (single iteration contains of multiple (usually millions) of invocations)
+            // it can influence the allocation-heavy Task<T> benchmarks
+            var gcMode = new GcMode { Force = false };
+
+            var customConfig = ManualConfig
+                .Create(DefaultConfig.Instance) // copies all exporters, loggers and basic stuff
+                .With(MemoryDiagnoser.Default) // use memory diagnoser
+                .With(Job.Default.With(gcMode));
+
+#if NET462
+            // enable the Inlining Diagnoser to find out what does not get inlined
+            // uncomment it first, it produces a lot of output
+            //customConfig = customConfig.With(new BenchmarkDotNet.Diagnostics.Windows.InliningDiagnoser(logFailuresOnly: true, filterByNamespace: true));
+#endif
+
+            var summary = BenchmarkRunner.Run<Benchmarker>(customConfig);
             Console.WriteLine(summary);
         }
     }
-    [MemoryDiagnoser]
+
     public class Benchmarker
     {
         static OrderBook _book;
@@ -28,7 +48,7 @@ namespace TheAwaitingGame
             var rand = new Random(12345);
 
             var book = new OrderBook();
-            for(int i = 0; i < 50; i++)
+            for (int i = 0; i < 50; i++)
             {
                 var order = new Order();
                 int lines = rand.Next(1, 10);
@@ -37,7 +57,7 @@ namespace TheAwaitingGame
                     order.Lines.Add(new OrderLine
                     {
                         Quantity = rand.Next(1, 20),
-                        UnitPrice = 0.01M * rand.Next(1,5000)
+                        UnitPrice = 0.01M * rand.Next(1, 5000)
                     });
                 }
                 book.Orders.Add(order);
@@ -53,7 +73,7 @@ namespace TheAwaitingGame
         public Task<decimal> TaskAsync() => _book.GetTotalWorthTaskAsync(REPEATS_PER_ITEM);
 
         [Benchmark]
-        public ValueTask<decimal> ValueTaskAsync() =>  _book.GetTotalWorthValueTaskAsync(REPEATS_PER_ITEM);
+        public ValueTask<decimal> ValueTaskAsync() => _book.GetTotalWorthValueTaskAsync(REPEATS_PER_ITEM);
 
         [Benchmark]
         public ValueTask<decimal> HandCrankedAsync() => _book.GetTotalWorthHandCrankedAsync(REPEATS_PER_ITEM);
@@ -149,7 +169,7 @@ namespace TheAwaitingGame
             decimal total = 0;
             using (var iter = Lines.GetEnumerator())
             {
-                while(iter.MoveNext())
+                while (iter.MoveNext())
                 {
                     var task = iter.Current.GetLineWorthHandCrankedAsync();
                     if (!task.IsCompleted) return ContinueAsync(total, task, iter);
@@ -178,6 +198,8 @@ namespace TheAwaitingGame
         public decimal GetLineWorth() => Quantity * UnitPrice;
         public Task<decimal> GetLineWorthTaskAsync() => Task.FromResult(Quantity * UnitPrice);
         public ValueTask<decimal> GetLineWorthValueTaskAsync() => new ValueTask<decimal>(Quantity * UnitPrice);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // it fails to inline by default due to "Native estimate for function size exceeds threshold."
         public ValueTask<decimal> GetLineWorthHandCrankedAsync() => new ValueTask<decimal>(Quantity * UnitPrice);
     }
 }

--- a/src/TheAwaitingGame/TheAwaitingGame.csproj
+++ b/src/TheAwaitingGame/TheAwaitingGame.csproj
@@ -6,7 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.3.111" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.3.111" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
`ValueTask<T>` can have two advantages over `Task<T>`:
* Less heap allocations (MemoryDiagnoser proves that)
* Method inlining is possible

BenchmarkDotNet has another great feature: InliningDiagnoser which shows which method do not get inlined.

Once you use it you can see that:

* `ValueTask<decimal> GetLineWorthHandCrankedAsync()` does not get inlined due to `"Native estimate for function size exceeds threshold."` Other (Task ans sync) versions also don't get inlined.
* methods that contain async/await don't get inlined due to the code that async task method builder generates (exception handling for example)
* methods that are using `foreach` on `List<T>` don't get inlined because they contain exception handling block (finally):
```cs
var enumerator = list.GetEnumerator();
try
{
  while(enumerator.MoveNext())
  {
     Consume(enumerator.Current);
  }
}
finally
{
   enumerator.Dispose(); // or .Reset()
}
```

Which explains why the "hand cranked" version is faster.

My output:

``` ini

BenchmarkDotNet=v0.10.3.111-nightly, OS=Windows 10.0.14393
Processor=Intel(R) Core(TM) i7-6600U CPU 2.60GHz, ProcessorCount=4
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0
  Job-NJYLUU : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0

Force=False  

```
 |           Method |      Mean |    StdDev |     Gen 0 |  Allocated |
 |----------------- |----------:|----------:|----------:|-----------:|
 |             Sync | 2.8457 ms | 0.0033 ms |         - |    0.03 kB |
 |        TaskAsync | 4.7486 ms | 0.0139 ms | 3188.5417 | 6688.33 kB |
 |   ValueTaskAsync | 5.7777 ms | 0.0119 ms |         - |    0.03 kB |
 | HandCrankedAsync | 3.9200 ms | 0.0107 ms |         - |    0.03 kB |

```
// * Diagnostic Output - InliningDiagnoser *
--------------------

--------------------
Benchmarker.Sync: Job-NJYLUU(Force=False)
--------------------
Inliner: BenchmarkDotNet.Autogenerated.Runnable..ctor - instance void  ()
Inlinee: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Fail Reason: Inlinee's class could not be initialized.
--------------------
Inliner: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Inlinee: System.GC.KeepAlive - void  (class System.Object)
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Benchmarker.Sync - instance value class System.Decimal  ()
Inlinee: TheAwaitingGame.OrderBook.GetTotalWorth - instance value class System.Decimal  (int32)
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorth - instance value class System.Decimal  (int32)
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorth - instance value class System.Decimal  (int32)
Inlinee: TheAwaitingGame.Order.GetOrderWorth - instance value class System.Decimal  ()
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorth - instance value class System.Decimal  ()
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorth - instance value class System.Decimal  ()
Inlinee: TheAwaitingGame.OrderLine.GetLineWorth - instance value class System.Decimal  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------

--------------------
Benchmarker.TaskAsync: Job-NJYLUU(Force=False)
--------------------
Inliner: BenchmarkDotNet.Autogenerated.Runnable..ctor - instance void  ()
Inlinee: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Fail Reason: Inlinee's class could not be initialized.
--------------------
Inliner: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Inlinee: System.GC.KeepAlive - void  (class System.Object)
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Benchmarker.TaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  ()
Inlinee: TheAwaitingGame.OrderBook.GetTotalWorthTaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  (int32)
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorthTaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  (int32)
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].Start - instance generic void  (!!0&)
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorthTaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  (int32)
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].get_Task - instance class System.Threading.Tasks.Task`1<!0>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].Start - instance generic void  (!!0&)
Inlinee: TheAwaitingGame.OrderBook+<GetTotalWorthTaskAsync>d__4.MoveNext - instance void  ()
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].AwaitUnsafeOnCompleted - instance generic void  (!!0&,!!1&)
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].SetException - instance void  (class System.Exception)
Fail Reason: Will not inline blocks that are in the catch handler region.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: TheAwaitingGame.Order.GetOrderWorthTaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].SetResult - instance void  (!0)
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorthTaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].Start - instance generic void  (!!0&)
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorthTaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].get_Task - instance class System.Threading.Tasks.Task`1<!0>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].Start - instance generic void  (!!0&)
Inlinee: TheAwaitingGame.Order+<GetOrderWorthTaskAsync>d__4.MoveNext - instance void  ()
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].AwaitUnsafeOnCompleted - instance generic void  (!!0&,!!1&)
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].SetException - instance void  (class System.Exception)
Fail Reason: Will not inline blocks that are in the catch handler region.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: TheAwaitingGame.OrderLine.GetLineWorthTaskAsync - instance class System.Threading.Tasks.Task`1<value class System.Decimal>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthTaskAsync>d__4.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].SetResult - instance void  (!0)
Fail Reason: Native estimate for function size exceeds threshold.
--------------------

--------------------
Benchmarker.ValueTaskAsync: Job-NJYLUU(Force=False)
--------------------
Inliner: BenchmarkDotNet.Autogenerated.Runnable..ctor - instance void  ()
Inlinee: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Fail Reason: Inlinee's class could not be initialized.
--------------------
Inliner: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Inlinee: System.GC.KeepAlive - void  (class System.Object)
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Benchmarker.ValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Inlinee: TheAwaitingGame.OrderBook.GetTotalWorthValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (int32)
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorthValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (int32)
Inlinee: System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.Decimal].Create - value class System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<!0>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorthValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (int32)
Inlinee: System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.Decimal].get_Task - instance value class System.Threading.Tasks.ValueTask`1<!0>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].Start - instance generic void  (!!0&)
Inlinee: TheAwaitingGame.OrderBook+<GetTotalWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.Decimal].SetException - instance void  (class System.Exception)
Fail Reason: Will not inline blocks that are in the catch handler region.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: TheAwaitingGame.Order.GetOrderWorthValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.OrderBook+<GetTotalWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.ValueTaskAwaiter`1[System.Decimal].GetResult - instance !0  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorthValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Inlinee: System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.Decimal].Create - value class System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<!0>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorthValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Inlinee: System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.Decimal].get_Task - instance value class System.Threading.Tasks.ValueTask`1<!0>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.Decimal].Start - instance generic void  (!!0&)
Inlinee: TheAwaitingGame.Order+<GetOrderWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1[System.Decimal].SetException - instance void  (class System.Exception)
Fail Reason: Will not inline blocks that are in the catch handler region.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: TheAwaitingGame.OrderLine.GetLineWorthValueTaskAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.Order+<GetOrderWorthValueTaskAsync>d__5.MoveNext - instance void  ()
Inlinee: System.Runtime.CompilerServices.ValueTaskAwaiter`1[System.Decimal].GetResult - instance !0  ()
Fail Reason: Native estimate for function size exceeds threshold.
--------------------

--------------------
Benchmarker.HandCrankedAsync: Job-NJYLUU(Force=False)
--------------------
Inliner: BenchmarkDotNet.Autogenerated.Runnable..ctor - instance void  ()
Inlinee: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Fail Reason: Inlinee's class could not be initialized.
--------------------
Inliner: TheAwaitingGame.Benchmarker..ctor - instance void  ()
Inlinee: System.GC.KeepAlive - void  (class System.Object)
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Benchmarker.HandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Inlinee: TheAwaitingGame.OrderBook.GetTotalWorthHandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (int32)
Fail Reason: Inlinee writes to an argument.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorthHandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (int32)
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorthHandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (int32)
Inlinee: TheAwaitingGame.Order.GetOrderWorthHandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Fail Reason: Inlinee contains EH.
--------------------
Inliner: TheAwaitingGame.OrderBook.GetTotalWorthHandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (int32)
Inlinee: TheAwaitingGame.OrderBook.ContinueAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (value class System.Decimal,value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>,int32,value class Enumerator<class TheAwaitingGame.Order>)
Fail Reason: Native estimate for function size exceeds threshold.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorthHandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Inlinee: System.Collections.Generic.List`1+Enumerator[System.__Canon].MoveNext - instance bool  ()
Fail Reason: Method is marked as no inline or has a cached result.
--------------------
Inliner: TheAwaitingGame.Order.GetOrderWorthHandCrankedAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  ()
Inlinee: TheAwaitingGame.Order.ContinueAsync - instance value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>  (value class System.Decimal,value class System.Threading.Tasks.ValueTask`1<value class System.Decimal>,value class Enumerator<class TheAwaitingGame.OrderLine>)
Fail Reason: Native estimate for function size exceeds threshold.
--------------------


// ***** BenchmarkRunner: End *****
```
