### PR TITLE
Added wrapped ValueTask benchmark to TheAwaiting Game.

### DIFF
--- a/src/TheAwaitingGame/Program.cs
+++ b/src/TheAwaitingGame/Program.cs
@@ -83,6 +83,9 @@ namespace TheAwaitingGame
         public ValueTask<decimal> ValueTaskAsync() => _book.GetTotalWorthValueTaskAsync(REPEATS_PER_ITEM);
 
         [Benchmark(OperationsPerInvoke = REPEATS_PER_ITEM)]
+        public ValueTask<decimal> ValueTaskWrappedAsync() => _book.GetTotalWorthValueTaskCheckedWrappedAsync(REPEATS_PER_ITEM);
+
+        [Benchmark(OperationsPerInvoke = REPEATS_PER_ITEM)]
         public ValueTask<decimal> ValueTaskCheckedAsync() => _book.GetTotalWorthValueTaskCheckedAsync(REPEATS_PER_ITEM);
 
         [Benchmark(OperationsPerInvoke = REPEATS_PER_ITEM)]
@@ -156,6 +159,19 @@ namespace TheAwaitingGame
                 {
                     var task = order.GetOrderWorthValueTaskCheckedAsync();
                     total += (task.IsCompleted) ? task.Result : await task;
+                }
+            }
+            return total;
+        }
+        public async ValueTask<decimal> GetTotalWorthValueTaskCheckedWrappedAsync(int repeats)
+        {
+            decimal total = 0;
+            while (repeats-- > 0)
+            {
+                foreach (var order in Orders)
+                {
+                    var task = order.GetOrderWorthValueTaskCheckedAsync();
+                    total += await task.AsTask();
                 }
             }
             return total;


### PR DESCRIPTION
Interesting result. Wrapping the `ValueTask` with `AsTask()` and letting the compiler do the work is almost as good as the checked version. 

``` ini

BenchmarkDotNet=v0.10.3.111-nightly, OS=Windows 10.0.15063
Processor=Intel(R) Core(TM) i5-2500K CPU 3.30GHz, ProcessorCount=4
Frequency=3222682 Hz, Resolution=310.3006 ns, Timer=TSC
dotnet cli version=1.0.2
  [Host]     : .NET Core 4.6.25009.03, 64bit RyuJIT [AttachedDebugger]
  Job-APDCGX : .NET Core 4.6.25009.03, 64bit RyuJIT

Force=False  

```
 |                Method |       Mean |    StdDev |     Op/s |  Gen 0 | Allocated |
 |---------------------- |-----------:|----------:|---------:|-------:|----------:|
 |                  Sync | 11.2569 us | 0.0537 us | 88834.76 |      - |      0 kB |
 |             TaskAsync | 18.2125 us | 0.1772 us | 54907.36 | 7.7292 |  24.25 kB |
 |      TaskCheckedAsync | 18.2587 us | 0.1573 us | 54768.49 | 7.7292 |  24.25 kB |
 |        ValueTaskAsync | 20.9975 us | 0.0183 us | 47624.83 |      - |      0 kB |
 | ValueTaskWrappedAsync | 19.7426 us | 0.0236 us | 50651.85 | 1.2708 |   3.99 kB |
 | ValueTaskCheckedAsync | 19.2869 us | 0.1780 us | 51848.78 |      - |      0 kB |
 |      HandCrankedAsync | 14.6249 us | 0.0111 us | 68376.69 |      - |      0 kB |
 |  AssertCompletedAsync | 15.8752 us | 0.0149 us | 62991.31 |      - |      0 kB |