### PR TITLE
Fix for Issue #162 

### DIFF
--- a/src/protobuf-net.Test/Serializers/UriTests.cs
+++ b/src/protobuf-net.Test/Serializers/UriTests.cs
@@ -1,0 +1,71 @@
+using System;
+
+using ProtoBuf.Meta;
+
+using Xunit;
+
+namespace ProtoBuf.unittest.Serializers
+{
+    public class UriTests
+    {
+        public class TypeWithUri
+        {
+            public Uri Value { get; set; }
+        }
+
+        [Theory]
+        [InlineData("http://example.com")]
+        [InlineData(@"/relative/path/to/file.txt")]
+        public void TestUriRuntime(string uriString)
+        {
+            var model = CreateModel();
+
+            var obj = new TypeWithUri { Value = new Uri(uriString, UriKind.RelativeOrAbsolute) };
+            TypeWithUri clone = (TypeWithUri) model.DeepClone(obj);
+            Assert.Equal(obj.Value, clone.Value);
+        }
+
+        [Theory]
+        [InlineData("http://example.com")]
+        [InlineData(@"/relative/path/to/file.txt")]
+        public void TestUriInPlace(string uriString)
+        {
+            var model = CreateModel();
+            model.CompileInPlace();
+            var obj = new TypeWithUri { Value = new Uri(uriString, UriKind.RelativeOrAbsolute) };
+
+            TypeWithUri clone = (TypeWithUri)model.DeepClone(obj);
+            
+            Assert.Equal(obj.Value, clone.Value);
+        }
+
+        [Fact]
+        public void TestUriCanCompileFully()
+        {
+            var model = CreateModel().Compile("TestUriCanCompileFully", "TestUriCanCompileFully.dll");
+            PEVerify.Verify("TestUriCanCompileFully.dll");
+        }
+
+        [Theory]
+        [InlineData("http://example.com")]
+        [InlineData(@"/relative/path/to/file.txt")]
+        public void TestUriCompiled(string uriString)
+        {
+            var model = CreateModel().Compile();
+
+            var obj = new TypeWithUri { Value = new Uri(uriString, UriKind.RelativeOrAbsolute) };
+
+            TypeWithUri clone = (TypeWithUri)model.DeepClone(obj);            
+            Assert.Equal(obj.Value, clone.Value);
+        }
+
+
+        static RuntimeTypeModel CreateModel()
+        {
+            var model = TypeModel.Create();
+            model.Add(typeof(TypeWithUri), false)
+                .Add(1, "Value");
+            return model;
+        }
+    }
+}

--- a/src/protobuf-net.Test/Serializers/UriTests.cs
+++ b/src/protobuf-net.Test/Serializers/UriTests.cs
@@ -80,6 +80,24 @@ namespace ProtoBuf.unittest.Serializers
             Assert.Equal(obj.Value, clone.Value);
         }
 
+        [Theory]
+        [InlineData("http://example.com", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource with spaces/", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource%20with%20spaces%20encoded", UriKind.Absolute)]
+        [InlineData("http://example.com/withquerystring?param1=1&param2=second", UriKind.Absolute)]
+        [InlineData("http://example.com/withfragment?param=test#anchorname", UriKind.Absolute)]
+        [InlineData("/relative/path/to/file.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file with spaces.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file%20with%20spaces%20encoded.txt", UriKind.Relative)]
+        public void TestUriDirect(string uriString, UriKind uriKind)
+        {
+            var model = TypeModel.Create();
+
+            var obj = new Uri(uriString, uriKind);
+            Uri clone = (Uri)model.DeepClone(obj);
+            Assert.Equal(obj, clone);
+        }
 
         static RuntimeTypeModel CreateModel()
         {

--- a/src/protobuf-net.Test/Serializers/UriTests.cs
+++ b/src/protobuf-net.Test/Serializers/UriTests.cs
@@ -14,25 +14,39 @@ namespace ProtoBuf.unittest.Serializers
         }
 
         [Theory]
-        [InlineData("http://example.com")]
-        [InlineData(@"/relative/path/to/file.txt")]
-        public void TestUriRuntime(string uriString)
+        [InlineData("http://example.com", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource with spaces/", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource%20with%20spaces%20encoded", UriKind.Absolute)]
+        [InlineData("http://example.com/withquerystring?param1=1&param2=second", UriKind.Absolute)]
+        [InlineData("http://example.com/withfragment?param=test#anchorname", UriKind.Absolute)]
+        [InlineData("/relative/path/to/file.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file with spaces.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file%20with%20spaces%20encoded.txt", UriKind.Relative)]
+        public void TestUriRuntime(string uriString, UriKind uriKind)
         {
             var model = CreateModel();
 
-            var obj = new TypeWithUri { Value = new Uri(uriString, UriKind.RelativeOrAbsolute) };
+            var obj = new TypeWithUri { Value = new Uri(uriString, uriKind) };
             TypeWithUri clone = (TypeWithUri) model.DeepClone(obj);
             Assert.Equal(obj.Value, clone.Value);
         }
 
         [Theory]
-        [InlineData("http://example.com")]
-        [InlineData(@"/relative/path/to/file.txt")]
-        public void TestUriInPlace(string uriString)
+        [InlineData("http://example.com", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource with spaces/", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource%20with%20spaces%20encoded", UriKind.Absolute)]
+        [InlineData("http://example.com/withquerystring?param1=1&param2=second", UriKind.Absolute)]
+        [InlineData("http://example.com/withfragment?param=test#anchorname", UriKind.Absolute)]
+        [InlineData("/relative/path/to/file.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file with spaces.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file%20with%20spaces%20encoded.txt", UriKind.Relative)]
+        public void TestUriInPlace(string uriString, UriKind uriKind)
         {
             var model = CreateModel();
             model.CompileInPlace();
-            var obj = new TypeWithUri { Value = new Uri(uriString, UriKind.RelativeOrAbsolute) };
+            var obj = new TypeWithUri { Value = new Uri(uriString, uriKind) };
 
             TypeWithUri clone = (TypeWithUri)model.DeepClone(obj);
             
@@ -47,13 +61,20 @@ namespace ProtoBuf.unittest.Serializers
         }
 
         [Theory]
-        [InlineData("http://example.com")]
-        [InlineData(@"/relative/path/to/file.txt")]
-        public void TestUriCompiled(string uriString)
+        [InlineData("http://example.com", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource with spaces/", UriKind.Absolute)]
+        [InlineData("http://example.com/path/to/resource%20with%20spaces%20encoded", UriKind.Absolute)]
+        [InlineData("http://example.com/withquerystring?param1=1&param2=second", UriKind.Absolute)]
+        [InlineData("http://example.com/withfragment?param=test#anchorname", UriKind.Absolute)]
+        [InlineData("/relative/path/to/file.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file with spaces.txt", UriKind.Relative)]
+        [InlineData("/relative/path/to/file%20with%20spaces%20encoded.txt", UriKind.Relative)]
+        public void TestUriCompiled(string uriString, UriKind uriKind)
         {
             var model = CreateModel().Compile();
 
-            var obj = new TypeWithUri { Value = new Uri(uriString, UriKind.RelativeOrAbsolute) };
+            var obj = new TypeWithUri { Value = new Uri(uriString, uriKind) };
 
             TypeWithUri clone = (TypeWithUri)model.DeepClone(obj);            
             Assert.Equal(obj.Value, clone.Value);

--- a/src/protobuf-net/Meta/TypeModel.cs
+++ b/src/protobuf-net/Meta/TypeModel.cs
@@ -164,7 +164,7 @@ namespace ProtoBuf.Meta
                 case ProtoTypeCode.ByteArray: ProtoWriter.WriteBytes((byte[])value, writer); return true;
                 case ProtoTypeCode.TimeSpan: BclHelpers.WriteTimeSpan((TimeSpan)value, writer); return true;
                 case ProtoTypeCode.Guid: BclHelpers.WriteGuid((Guid)value, writer); return true;
-                case ProtoTypeCode.Uri: ProtoWriter.WriteString(((Uri)value).AbsoluteUri, writer); return true;
+                case ProtoTypeCode.Uri: ProtoWriter.WriteString(((Uri)value).OriginalString, writer); return true;
             }
 
             // by now, we should have covered all the simple cases; if we wrote a field-header, we have
@@ -1196,7 +1196,7 @@ namespace ProtoBuf.Meta
                     case ProtoTypeCode.ByteArray: value = ProtoReader.AppendBytes((byte[])value, reader); continue;
                     case ProtoTypeCode.TimeSpan: value = BclHelpers.ReadTimeSpan(reader); continue;
                     case ProtoTypeCode.Guid: value = BclHelpers.ReadGuid(reader); continue;
-                    case ProtoTypeCode.Uri: value = new Uri(reader.ReadString()); continue; 
+                    case ProtoTypeCode.Uri: value = new Uri(reader.ReadString(), UriKind.RelativeOrAbsolute); continue; 
                 }
 
             }


### PR DESCRIPTION
This is a fix to support the serialization of relative URIs. The current version causes an error on serialization because the property "AbsoluteUri" throws when using relative URIs.

Test cases were added to ensure that the modification to the IL generation made by UriDecorator works.

Issue link: https://github.com/mgravell/protobuf-net/issues/162