### PR TITLE
Invalid program exception

### DIFF
--- a/src/Examples/Issues/Issue210.cs
+++ b/src/Examples/Issues/Issue210.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+using Xunit;
+using ProtoBuf;
+using ProtoBuf.Meta;
+
+namespace Examples.Issues
+{
+    public class Issue210
+    {
+        [ProtoContract]
+        public class ProtoTestOne
+        {
+            //This causes the exception
+            static ProtoTestOne()
+            {
+            }
+
+            public ProtoTestOne()
+            {
+            }
+        }
+
+        [Fact]
+        public void ShouldDeserializeWithStaticConstructor()
+        {
+            var typeModel = TypeModel.Create();
+            typeModel.AutoCompile = true;
+            typeModel.Deserialize(new MemoryStream(), null, typeof(ProtoTestOne));
+        }
+    }
+}

--- a/src/protobuf-net/Helpers.cs
+++ b/src/protobuf-net/Helpers.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections;
 using System.IO;
-
+using System.Linq;
 #if FEAT_IKVM
 using Type = IKVM.Reflection.Type;
 using IKVM.Reflection;
@@ -497,18 +497,11 @@ namespace ProtoBuf
         }
         internal static ConstructorInfo GetConstructor(TypeInfo type, Type[] parameterTypes, bool nonPublic)
         {
-            foreach (ConstructorInfo ctor in type.DeclaredConstructors)
-            {
-                if (!nonPublic && !ctor.IsPublic) continue;
-                if (IsMatch(ctor.GetParameters(), parameterTypes)) return ctor;
-            }
-            return null;
+            return GetConstructors(type, nonPublic).SingleOrDefault(ctor => IsMatch(ctor.GetParameters(), parameterTypes));
         }
         internal static ConstructorInfo[] GetConstructors(TypeInfo typeInfo, bool nonPublic)
         {
-            if (nonPublic) return System.Linq.Enumerable.ToArray(typeInfo.DeclaredConstructors);
-            return System.Linq.Enumerable.ToArray(
-                System.Linq.Enumerable.Where(typeInfo.DeclaredConstructors, x => x.IsPublic));
+            return typeInfo.DeclaredConstructors.Where(c => !c.IsStatic && (nonPublic || c.IsPublic)).ToArray();
         }
         internal static PropertyInfo GetProperty(Type type, string name, bool nonPublic)
         {


### PR DESCRIPTION
Fixes #210.
The bug happens only on .NET Core because DeclaredConstructors returns the static one too.
In my experience, it is best to try to run the exact same code on multiple frameworks so bugs would manifest everywhere. But the new reflection stuff started in 4.5, so I guess that's not an option with 4.0.