### PR TITLE
Cache TypeModel GetKey calls

### DIFF
--- a/src/protobuf-net/Meta/TypeModel.cs
+++ b/src/protobuf-net/Meta/TypeModel.cs
@@ -1279,6 +1279,8 @@ namespace ProtoBuf.Meta
         {
             return GetKey(ref type) >= 0;
         }
+
+        Dictionary<Type, int> last = new Dictionary<Type, int>();
         /// <summary>
         /// Provides the key that represents a given type in the current model.
         /// The type is also normalized for proxies at the same time.
@@ -1286,7 +1288,12 @@ namespace ProtoBuf.Meta
         protected internal int GetKey(ref Type type)
         {
             if (type == null) return -1;
-            int key = GetKeyImpl(type);
+            int key;
+            lock(last)
+            {
+                if (!last.TryGetValue(type, out key))
+                    key = last[type] = GetKeyImpl(type);
+            }
             if (key < 0)
             {
                 Type normalized = ResolveProxies(type);


### PR DESCRIPTION
I've been using ProtoBuf to serialize code in some high frequency sections of programs, and found a rather significant performance improvement when serializing IEnumerables. I noticed that serializing IEnumerables took about 10x longer than serializing the underlying items directly. My, potentially naive, solution is to cache calls to `int GetKey(Type)` in TypeModel. Using the following benchmark I was able to confirm that this results in a speedup of around 10.

```c#
var stats = new Dictionary<string, float>
{
    {"1", 1 },
    {"2", 1 },
    {"3", 1 },
    {"4", 1 },
    {"5", 1 },
    {"6", 1 },
    {"7", 1 },
    {"8", 1 },
};
var stream = new MemoryStream();
var s = new Stopwatch();
s.Start();
for(int i = 0; i < 1e5; i++)
{
    Serializer.Serialize(stream, stats);
}
s.Stop();
Console.WriteLine(s.ElapsedTicks * 1.0 / Stopwatch.Frequency);
stream = new MemoryStream();
s.Restart();
for (int i = 0; i < 8e5; i++)
{
    Serializer.Serialize(stream, new KeyValuePair<string, float>("1", 1));
}
s.Stop();
Console.WriteLine(s.ElapsedTicks * 1.0 / Stopwatch.Frequency);
```

Potential downsides to this approach include a possible memory leak on the lookup, if the set of types being serialized by the program is not fixed at compile time and includes run time generated types. I think this case is relatively rare, but otherwise I can complicate the caching mechanism to store the last N lookups.