### PR TITLE
Allow model precompilation for 'unknown' types

### DIFF
--- a/src/protobuf-net/Serializer.cs
+++ b/src/protobuf-net/Serializer.cs
@@ -245,23 +245,13 @@ namespace ProtoBuf
         }
 #endif
 
-        /// <summary>
-        /// Precompiles the serializer for a given type.
-        /// </summary>
-        public static void PrepareSerializer(Type t) {
-#if FEAT_COMPILER
-            RuntimeTypeModel model = RuntimeTypeModel.Default;
-            model[model.MapType(t)].CompileInPlace();
-#endif
-        }
-
 #if !NO_GENERICS
         /// <summary>
         /// Precompiles the serializer for a given type.
         /// </summary>
         public static void PrepareSerializer<T>()
         {
-            PrepareSerializer(typeof(T));
+            NonGeneric.PrepareSerializer(typeof(T));
         }
 
 #if PLAT_BINARYFORMATTER && !(WINRT || PHONE8 || COREFX)
@@ -507,7 +497,15 @@ namespace ProtoBuf
             {
                 return RuntimeTypeModel.Default.IsDefined(type);
             }
-
+            /// <summary>
+            /// Precompiles the serializer for a given type.
+            /// </summary>
+            public static void PrepareSerializer(Type t) {
+#if FEAT_COMPILER
+                RuntimeTypeModel model = RuntimeTypeModel.Default;
+                model[model.MapType(t)].CompileInPlace();
+#endif
+            }
         }
 
 

--- a/src/protobuf-net/Serializer.cs
+++ b/src/protobuf-net/Serializer.cs
@@ -245,16 +245,23 @@ namespace ProtoBuf
         }
 #endif
 
+        /// <summary>
+        /// Precompiles the serializer for a given type.
+        /// </summary>
+        public static void PrepareSerializer(Type t) {
+#if FEAT_COMPILER
+            RuntimeTypeModel model = RuntimeTypeModel.Default;
+            model[model.MapType(t)].CompileInPlace();
+#endif
+        }
+
 #if !NO_GENERICS
         /// <summary>
         /// Precompiles the serializer for a given type.
         /// </summary>
         public static void PrepareSerializer<T>()
-        { 
-#if FEAT_COMPILER
-            RuntimeTypeModel model = RuntimeTypeModel.Default;
-            model[model.MapType(typeof(T))].CompileInPlace();
-#endif
+        {
+            PrepareSerializer(typeof(T));
         }
 
 #if PLAT_BINARYFORMATTER && !(WINRT || PHONE8 || COREFX)


### PR DESCRIPTION
PrepareSerializer<T>() can only be used with types known at compile time.

PrepareSerializer(Type t) can also be used with types discovered via reflection.