### PR TITLE
Added switch to avoid interning strings during deserialization

### DIFF
--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -38,7 +38,8 @@ namespace ProtoBuf.Meta
            OPTIONS_UseImplicitZeroDefaults = 32,
            OPTIONS_AllowParseableTypes = 64,
            OPTIONS_AutoAddProtoContractTypesOnly = 128,
-           OPTIONS_IncludeDateTimeKind = 256;
+           OPTIONS_IncludeDateTimeKind = 256,
+           OPTIONS_DoNotInternStrings = 512;
         private bool GetOption(ushort option)
         {
             return (options & option) == option;
@@ -111,7 +112,14 @@ namespace ProtoBuf.Meta
             get { return GetOption(OPTIONS_IncludeDateTimeKind); }
             set { SetOption(OPTIONS_IncludeDateTimeKind, value); }
         }
-
+        /// <summary>
+        /// Global switch that determines whether a single instance of the same string should be used during deserialization.
+        /// </summary>
+        public bool DoNotInternStrings
+        {
+            get { return GetOption(OPTIONS_DoNotInternStrings); }
+            set { SetOption(OPTIONS_DoNotInternStrings, value); }
+        }
         /// <summary>
         /// Should the <c>Kind</c> be included on date/time values?
         /// </summary>

--- a/src/protobuf-net/ProtoReader.cs
+++ b/src/protobuf-net/ProtoReader.cs
@@ -110,7 +110,7 @@ namespace ProtoBuf
             reader.position64 = 0;
             reader.available = reader.depth = reader.fieldNumber = reader.ioIndex = 0;
             reader.blockEnd64 = long.MaxValue;
-            reader.internStrings = true;
+            reader.internStrings = !RuntimeTypeModel.Default.DoNotInternStrings;
             reader.wireType = WireType.None;
             reader.trapCount = 1;
             if(reader.netCache == null) reader.netCache = new NetObjectCache();            


### PR DESCRIPTION

![protobuf-gc](https://user-images.githubusercontent.com/958861/34164330-54f37ea8-e4ea-11e7-9ec2-c840362e50e9.png)
I tested and profiled (with dotMemory) deserialization with protobuf-net, and found that "interning" strings creates a lot of memory pressure without any benefits because I don't have any repeating string normally. 
So I've created a switch which disables such interning. Not sure whether I placed it to the right place so feel free to notice it, I will rearrange things in this case. 