### PR TITLE
Allow surrogates to be defined for custom collection types

### DIFF
--- a/src/protobuf-net.Test/Issues/CustomListSurrogate.cs
+++ b/src/protobuf-net.Test/Issues/CustomListSurrogate.cs
@@ -1,0 +1,82 @@
+﻿using ProtoBuf.Meta;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace ProtoBuf.Issues
+{
+    public class CustomListSurrogate
+    {
+        [Fact]
+        public void CustomCollectionSurrogateWorks()
+        {
+            var model = RuntimeTypeModel.Create();
+
+            var modelType = model.Add(typeof(List<string>), false);
+            modelType.SetSurrogate(typeof(EmptyListIsNotNullSurrogate<string>));
+            modelType.IgnoreListHandling = true;
+            modelType.CompileInPlace();
+            
+            var input = new TestSerialisedObject { Data = new List<string>() { "TEST", "TEST2" } };
+
+            var clonedObject = model.DeepClone(input);
+
+            Assert.Equal(input, clonedObject);
+        }
+
+        [ProtoContract]
+        private class TestSerialisedObject
+        {
+            [ProtoMember(1)]
+            public List<string> Data { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                var @object = obj as TestSerialisedObject;
+                return @object != null && Enumerable.SequenceEqual(this.Data, @object.Data);
+            }
+
+            public override int GetHashCode()
+            {
+                return 1;
+            }
+        }
+    }
+
+    [ProtoContract]
+    public class EmptyListIsNotNullSurrogate<T>
+    {
+        public EmptyListIsNotNullSurrogate()
+        {
+            Array = new T[0];
+        }
+
+        [ProtoMember(1)]
+        public T[] Array { get; set;} 
+
+        public static implicit operator EmptyListIsNotNullSurrogate<T>(List<T> l)
+        {
+            if (l == null)
+            {
+                return new EmptyListIsNotNullSurrogate<T>();
+            }
+
+            return new EmptyListIsNotNullSurrogate<T>()
+            {
+                Array = l.ToArray()
+            };
+        }
+
+        public static implicit operator List<T>(EmptyListIsNotNullSurrogate<T> l)
+        {
+            if (l == null)
+            {
+                return new List<T>();
+            }
+
+            return new List<T>(l.Array);
+        }
+    }
+}

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1487,9 +1487,12 @@ namespace ProtoBuf.Meta
             return newField;
         }
 
-        internal static void ResolveListTypes(TypeModel model, Type type, ref Type itemType, ref Type defaultType)
+        internal static void ResolveListTypes(RuntimeTypeModel model, Type type, ref Type itemType, ref Type defaultType)
         {
-            if (type == null) return;
+            // If the type is equal to Null or the type has a surrogate defined to handle this list it shouldn't be handled here.
+            if (type == null || (model.IsDefined(type) && model[type].IgnoreListHandling && model[type].surrogate != null))
+                return;
+
             // handle arrays
             if (type.IsArray)
             {


### PR DESCRIPTION
The IgnoreListHandling setting + using a surrogate setting doesn't work with custom collection types since the MetaType.ResolveListTypes doesn't check the IgnoreListHandling.

Note: If I check the IgnoreListHandling alone in the MetaType.ResolveListTypes method some tests around the CustomDictionary type fail hence the additional check for the surrogate.

This seemed to be the best spot based on my limited understanding of the code-base. I'm up for any suggestions/tweaks to get this out. My use case is that I want to be able to represent custom collection types (e.g F# collection types, some other faster ones as well) in my Protobuf projects AND change the deserialisation behaviour for empty lists to be an empty list rather than the current Null.