### PR TITLE
Support deserializing ImmutableArray<T> - Fixes issue #313

### DIFF
--- a/src/protobuf-net.Test/Issues/Immutables.cs
+++ b/src/protobuf-net.Test/Issues/Immutables.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using ProtoBuf.Meta;
+using Xunit;
+
+namespace ProtoBuf.Issues
+{
+    public class Immutables
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanDeserialiseImmutableArray(bool autoCompile)
+        {
+            var testClass = new ImmutableArrayTestClass(ImmutableArray.Create("a", "b", "c"));
+            var model = TypeModel.Create();
+            model.AutoCompile = autoCompile;
+
+            ImmutableArrayTestClass testClassClone;
+            using (var ms = new MemoryStream())
+            {
+                model.Serialize(ms, testClass);
+                ms.Position = 0;
+                testClassClone = (ImmutableArrayTestClass)model.Deserialize(ms, null, testClass.GetType());
+            }
+
+            Assert.Equal((IEnumerable<string>)testClass.Array, (IEnumerable<string>)testClassClone.Array);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanDeserialiseImmutableList(bool autoCompile)
+        {
+            var testClass = new ImmutableListTestClass(ImmutableList.Create("a", "b", "c"));
+            var model = TypeModel.Create();
+            model.AutoCompile = autoCompile;
+
+            ImmutableListTestClass testClassClone;
+            using (var ms = new MemoryStream())
+            {
+                model.Serialize(ms, testClass);
+                ms.Position = 0;
+                testClassClone = (ImmutableListTestClass)model.Deserialize(ms, null, testClass.GetType());
+            }
+
+            Assert.Equal((IEnumerable<string>)testClass.List, (IEnumerable<string>)testClassClone.List);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanDeserialiseImmutableHashSet(bool autoCompile)
+        {
+            var testClass = new ImmutableHashSetTestClass(ImmutableHashSet.Create("a", "b", "c"));
+            var model = TypeModel.Create();
+            model.AutoCompile = autoCompile;
+
+            ImmutableHashSetTestClass testClassClone;
+            using (var ms = new MemoryStream())
+            {
+                model.Serialize(ms, testClass);
+                ms.Position = 0;
+                testClassClone = (ImmutableHashSetTestClass)model.Deserialize(ms, null, testClass.GetType());
+            }
+
+            Assert.True(testClass.Set.SetEquals(testClassClone.Set));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanDeserialiseImmutableSortedSet(bool autoCompile)
+        {
+            var testClass = new ImmutableSortedSetTestClass(ImmutableSortedSet.Create("a", "b", "c"));
+            var model = TypeModel.Create();
+            model.AutoCompile = autoCompile;
+
+            ImmutableSortedSetTestClass testClassClone;
+            using (var ms = new MemoryStream())
+            {
+                model.Serialize(ms, testClass);
+                ms.Position = 0;
+                testClassClone = (ImmutableSortedSetTestClass)model.Deserialize(ms, null, testClass.GetType());
+            }
+
+            Assert.Equal((IEnumerable<string>)testClass.Set, (IEnumerable<string>)testClassClone.Set);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanDeserialiseImmutableDictionary(bool autoCompile)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string>();
+            builder.Add("a", "1");
+            builder.Add("b", "2");
+            builder.Add("c", "2");
+            var testClass = new ImmutableDictionaryTestClass(builder.ToImmutable());
+            var model = TypeModel.Create();
+            model.AutoCompile = autoCompile;
+
+            ImmutableDictionaryTestClass testClassClone;
+            using (var ms = new MemoryStream())
+            {
+                model.Serialize(ms, testClass);
+                ms.Position = 0;
+                testClassClone = (ImmutableDictionaryTestClass)model.Deserialize(ms, null, testClass.GetType());
+            }
+
+            Assert.Equal((IEnumerable<KeyValuePair<string, string>>)testClass.Dictionary.OrderBy(x => x.Key), (IEnumerable<KeyValuePair<string, string>>)testClassClone.Dictionary.OrderBy(x => x.Key));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanDeserialiseImmutableSortedDictionary(bool autoCompile)
+        {
+            var builder = ImmutableSortedDictionary.CreateBuilder<string, string>();
+            builder.Add("a", "1");
+            builder.Add("b", "2");
+            builder.Add("c", "2");
+            var testClass = new ImmutableSortedDictionaryTestClass(builder.ToImmutable());
+            var model = TypeModel.Create();
+            model.AutoCompile = autoCompile;
+
+            ImmutableSortedDictionaryTestClass testClassClone;
+            using (var ms = new MemoryStream())
+            {
+                model.Serialize(ms, testClass);
+                ms.Position = 0;
+                testClassClone = (ImmutableSortedDictionaryTestClass)model.Deserialize(ms, null, testClass.GetType());
+            }
+
+            Assert.Equal((IEnumerable<KeyValuePair<string, string>>)testClass.Dictionary, (IEnumerable<KeyValuePair<string, string>>)testClassClone.Dictionary);
+        }
+
+        [ProtoContract(SkipConstructor = true)]
+        public class ImmutableArrayTestClass
+        {
+            public ImmutableArrayTestClass(ImmutableArray<string> array)
+            {
+                Array = array;
+            }
+
+            [ProtoMember(1)]
+            public ImmutableArray<string> Array {get;}
+        }
+
+        [ProtoContract(SkipConstructor = true)]
+        public class ImmutableListTestClass
+        {
+            public ImmutableListTestClass(ImmutableList<string> list)
+            {
+                List = list;
+            }
+
+            [ProtoMember(1)]
+            public ImmutableList<string> List { get; }
+        }
+
+        [ProtoContract(SkipConstructor = true)]
+        public class ImmutableHashSetTestClass
+        {
+            public ImmutableHashSetTestClass(ImmutableHashSet<string> set)
+            {
+                Set = set;
+            }
+
+            [ProtoMember(1)]
+            public ImmutableHashSet<string> Set { get; }
+        }
+
+        [ProtoContract(SkipConstructor = true)]
+        public class ImmutableSortedSetTestClass
+        {
+            public ImmutableSortedSetTestClass(ImmutableSortedSet<string> set)
+            {
+                Set = set;
+            }
+
+            [ProtoMember(1)]
+            public ImmutableSortedSet<string> Set { get; }
+        }
+
+        [ProtoContract(SkipConstructor = true)]
+        public class ImmutableDictionaryTestClass
+        {
+            public ImmutableDictionaryTestClass(ImmutableDictionary<string, string> dictionary)
+            {
+                Dictionary = dictionary;
+            }
+
+            [ProtoMember(1)]
+            public ImmutableDictionary<string, string> Dictionary { get; }
+        }
+
+        [ProtoContract(SkipConstructor = true)]
+        public class ImmutableSortedDictionaryTestClass
+        {
+            public ImmutableSortedDictionaryTestClass(ImmutableSortedDictionary<string, string> dictionary)
+            {
+                Dictionary = dictionary;
+            }
+
+            [ProtoMember(1)]
+            public ImmutableSortedDictionary<string, string> Dictionary { get; }
+        }
+    }
+}

--- a/src/protobuf-net.Test/protobuf-net.Test.csproj
+++ b/src/protobuf-net.Test/protobuf-net.Test.csproj
@@ -19,6 +19,7 @@
     <DefineConstants>FEAT_COMPILER;FX30;NO_INTERNAL_CONTEXT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/src/protobuf-net/Meta/ValueMember.cs
+++ b/src/protobuf-net/Meta/ValueMember.cs
@@ -392,7 +392,7 @@ namespace ProtoBuf.Meta
 #else
                 var info = memberType;
 #endif
-                if (ImmutableCollectionDecorator.IdentifyImmutable(model, MemberType, out _, out _, out _, out _))
+                if (ImmutableCollectionDecorator.IdentifyImmutable(model, MemberType, out _, out _, out _, out _, out _, out _))
                 {
                     return false;
                 }

--- a/src/protobuf-net/Serializers/ImmutableCollectionDecorator.cs
+++ b/src/protobuf-net/Serializers/ImmutableCollectionDecorator.cs
@@ -49,9 +49,11 @@ namespace ProtoBuf.Serializers
 #endif
             return null;
         }
-        internal static bool IdentifyImmutable(TypeModel model, Type declaredType, out MethodInfo builderFactory, out MethodInfo add, out MethodInfo addRange, out MethodInfo finish)
+
+        internal static bool IdentifyImmutable(TypeModel model, Type declaredType, out MethodInfo builderFactory, out PropertyInfo isEmpty, out PropertyInfo length, out MethodInfo add, out MethodInfo addRange, out MethodInfo finish)
         {
             builderFactory = add = addRange = finish = null;
+            isEmpty = length = null;
             if (model == null || declaredType == null) return false;
 #if WINRT || COREFX
             TypeInfo declaredTypeInfo = declaredType.GetTypeInfo();
@@ -113,6 +115,23 @@ namespace ProtoBuf.Serializers
             Type voidType = model.MapType(typeof(void));
             if (builderFactory == null || builderFactory.ReturnType == null || builderFactory.ReturnType == voidType) return false;
 
+#if COREFX
+            TypeInfo typeInfo = declaredType.GetTypeInfo();
+#else
+            Type typeInfo = declaredType;
+#endif
+            isEmpty = Helpers.GetProperty(typeInfo, "IsDefaultOrEmpty", false); //struct based immutabletypes can have both a "default" and "empty" state
+            if (isEmpty == null) isEmpty = Helpers.GetProperty(typeInfo, "IsEmpty", false);
+            if (isEmpty == null)
+            {
+                //Fallback to checking length if a "IsEmpty" property is not found
+                length = Helpers.GetProperty(typeInfo, "Length", false);
+                if (length == null) length = Helpers.GetProperty(typeInfo, "Count", false);
+#if !NO_GENERICS
+                if (length == null) length = Helpers.GetProperty(ResolveIReadOnlyCollection(declaredType, effectiveType[0]), "Count", false);
+#endif
+                if (length == null) return false;
+            }
 
             add = Helpers.GetInstanceMethod(builderFactory.ReturnType, "Add", effectiveType);
             if (add == null) return false;
@@ -136,11 +155,14 @@ namespace ProtoBuf.Serializers
         }
 #endif
         private readonly MethodInfo builderFactory, add, addRange, finish;
+        private readonly PropertyInfo isEmpty, length;
         internal ImmutableCollectionDecorator(TypeModel model, Type declaredType, Type concreteType, IProtoSerializer tail, int fieldNumber, bool writePacked, WireType packedWireType, bool returnList, bool overwriteList, bool supportNull,
-            MethodInfo builderFactory, MethodInfo add, MethodInfo addRange, MethodInfo finish)
+            MethodInfo builderFactory, PropertyInfo isEmpty, PropertyInfo length, MethodInfo add, MethodInfo addRange, MethodInfo finish)
             : base(model, declaredType, concreteType, tail, fieldNumber, writePacked, packedWireType, returnList, overwriteList, supportNull)
         {
             this.builderFactory = builderFactory;
+            this.isEmpty = isEmpty;
+            this.length = length;
             this.add = add;
             this.addRange = addRange;
             this.finish = finish;
@@ -151,7 +173,7 @@ namespace ProtoBuf.Serializers
             object builderInstance = builderFactory.Invoke(null, null);
             int field = source.FieldNumber;
             object[] args = new object[1];
-            if (AppendToCollection && value != null && ((ICollection)value).Count != 0)
+            if (AppendToCollection && value != null && (isEmpty != null ? !(bool)isEmpty.GetValue(value, null) : (int)length.GetValue(value, null) != 0))
             {   
                 if(addRange !=null)
                 {
@@ -208,19 +230,18 @@ namespace ProtoBuf.Serializers
                         ctx.LoadValue(oldList);
                         ctx.BranchIfFalse(done, false); // old value null; nothing to add
                     }
-#if COREFX
-                    TypeInfo typeInfo = ExpectedType.GetTypeInfo();
-#else
-                    Type typeInfo = ExpectedType;
-#endif
-                    PropertyInfo prop = Helpers.GetProperty(typeInfo, "Length", false);
-                    if(prop == null) prop = Helpers.GetProperty(typeInfo, "Count", false);
-#if !NO_GENERICS
-                    if (prop == null) prop = Helpers.GetProperty(ResolveIReadOnlyCollection(ExpectedType, Tail.ExpectedType), "Count", false);
-#endif
+
                     ctx.LoadAddress(oldList, oldList.Type);
-                    ctx.EmitCall(Helpers.GetGetMethod(prop, false, false));
-                    ctx.BranchIfFalse(done, false); // old list is empty; nothing to add
+                    if (isEmpty != null)
+                    {
+                        ctx.EmitCall(Helpers.GetGetMethod(isEmpty, false, false));
+                        ctx.BranchIfTrue(done, false); // old list is empty; nothing to add
+                    }
+                    else
+                    {
+                        ctx.EmitCall(Helpers.GetGetMethod(length, false, false));
+                        ctx.BranchIfFalse(done, false); // old list is empty; nothing to add
+                    }
 
                     Type voidType = ctx.MapType(typeof(void));
                     if(addRange != null)

--- a/src/protobuf-net/Serializers/ListDecorator.cs
+++ b/src/protobuf-net/Serializers/ListDecorator.cs
@@ -54,11 +54,12 @@ namespace ProtoBuf.Serializers
         {
 #if !NO_GENERICS
             MethodInfo builderFactory, add, addRange, finish;
-            if (returnList && ImmutableCollectionDecorator.IdentifyImmutable(model, declaredType, out builderFactory, out add, out addRange, out finish))
+            PropertyInfo isEmpty, length;
+            if (returnList && ImmutableCollectionDecorator.IdentifyImmutable(model, declaredType, out builderFactory, out isEmpty, out length, out add, out addRange, out finish))
             {
                 return new ImmutableCollectionDecorator(
                     model, declaredType, concreteType, tail, fieldNumber, writePacked, packedWireType, returnList, overwriteList, supportNull,
-                    builderFactory, add, addRange, finish);
+                    builderFactory, isEmpty, length, add, addRange, finish);
             }
 
 #endif


### PR DESCRIPTION
Rather than using the Length or Count property to decide if the collection is empty (which doesn't work for ImmutableArray<T>) the code now uses the first found of the following properties (in priority order):
1) IsDefaultOrEmpty
2) IsEmpty
3) Length
4) Count

The first two are Boolean return and the second two are Int32 return, with the code handling both situations appropriately.

I have also implemented unit tests that test the serialisation/deserialization of the main immutable types.  If these tests are run without the other code modifications then all pass except the  ImmutableArray<T> tests.

I've tried to maintain the same coding standard in my (relatively limited) modifications but please let me know if you want me to modify anything further (style or code).