### PR TITLE
Support for targeting PCL 4.0 

### DIFF
--- a/src/protobuf-net/Serializers/ArrayDecorator.cs
+++ b/src/protobuf-net/Serializers/ArrayDecorator.cs
@@ -113,6 +113,7 @@ namespace ProtoBuf.Serializers
                 }
             }
         }
+#endif
 
         private bool CanUsePackedPrefix() => CanUsePackedPrefix(packedWireType, itemType);
         internal static bool CanUsePackedPrefix(WireType packedWireType,  Type itemType)
@@ -130,6 +131,7 @@ namespace ProtoBuf.Serializers
             return Helpers.GetUnderlyingType(itemType) == null;
         }
 
+#if FEAT_COMPILER
         private void EmitWriteArrayLoop(Compiler.CompilerContext ctx, Compiler.Local i, Compiler.Local arr)
         {
             // i = 0

--- a/src/protobuf-net/Serializers/MapDecorator.cs
+++ b/src/protobuf-net/Serializers/MapDecorator.cs
@@ -1,6 +1,8 @@
 ﻿using ProtoBuf.Meta;
 using System;
+#if FEAT_COMPILER
 using ProtoBuf.Compiler;
+#endif
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -107,6 +109,7 @@ namespace ProtoBuf.Serializers
             }
         }
 
+#if FEAT_COMPILER
         protected override void EmitWrite(CompilerContext ctx, Local valueFrom)
         {
             Type itemType = typeof(KeyValuePair<TKey, TValue>);
@@ -280,5 +283,6 @@ namespace ProtoBuf.Serializers
                 }
             }
         }
+#endif
     }
 }

--- a/src/protobuf-net/Serializers/ParseableSerializer.cs
+++ b/src/protobuf-net/Serializers/ParseableSerializer.cs
@@ -1,6 +1,5 @@
 ﻿#if !NO_RUNTIME
 using System;
-using System.Net;
 using ProtoBuf.Meta;
 #if FEAT_IKVM
 using Type = IKVM.Reflection.Type;

--- a/src/protobuf-net/Serializers/UriDecorator.cs
+++ b/src/protobuf-net/Serializers/UriDecorator.cs
@@ -1,7 +1,9 @@
 ﻿#if !NO_RUNTIME
 using System;
 
+#if FEAT_COMPILER
 using ProtoBuf.Compiler;
+#endif
 #if FEAT_IKVM
 using Type = IKVM.Reflection.Type;
 using IKVM.Reflection;

--- a/src/protobuf-net/protobuf-net.csproj
+++ b/src/protobuf-net/protobuf-net.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>protobuf-net</AssemblyName>
     <Title>protobuf-net</Title>
     <Description>Provides simple access to fast and efficient "Protocol Buffers" serialization from .NET applications</Description>
-    <TargetFrameworks>net20;net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;netstandard1.3;netstandard2.0;.NETPortable,Version=v4.0,Profile=Profile5</TargetFrameworks>
     <!--  -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>EMIT_ASSEMBLY_INFO</DefineConstants>
@@ -18,6 +18,18 @@
     <PlatformBinaryFormatter>true</PlatformBinaryFormatter>
     <Configurations>Debug;Release;VS</Configurations>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == '.NETPortable,Version=v4.0,Profile=Profile5'">
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile5</TargetFrameworkProfile>
+    <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
+    <PlatformXmlSerializer>false</PlatformXmlSerializer>
+    <FeatureCompiler>false</FeatureCompiler>
+    <FeatureServiceModel>false</FeatureServiceModel>
+    <PlatformBinaryFormatter>false</PlatformBinaryFormatter>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)' == 'VS'">
     <TargetFrameworks>$(TargetFrameworks);net20;net35</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
We have some legacy projects targeting PCL 4.0 and it was quite easy to add support for targeting platform by just using the feature toggles already defined.

(Isn't PCL deprecated? Yes, but since the migration to .NETstandard is quite heavy, reality is we won't get rid of it just yet).

If there is interest from more than us to support this, here's the pull request for it.