### PR TITLE
Fix ProtoReader.TryReadUIny64Variant Byte Count Result

### DIFF
--- a/src/Examples/Issues/Issue374.cs
+++ b/src/Examples/Issues/Issue374.cs
@@ -1,0 +1,54 @@
+﻿using Xunit;
+using ProtoBuf;
+using ProtoBuf.Meta;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Examples.Issues
+{
+    public class Issue374
+    {
+        [ProtoContract]
+        public class Issue374TestModel
+        {
+            [ProtoMember(1, IsRequired = true)]
+            public byte[] TestBytes { get; set; }
+
+            public Issue374TestModel()
+            {
+
+            }
+
+            public Issue374TestModel(byte[] bytes)
+            {
+                TestBytes = bytes;
+            }
+        }
+
+        [Fact]
+        public void ReadLengthPrefixProducesCorrectLengthComparedToStreamPosition()
+        {
+            byte[] bytes = null;
+            int arraySize = 7000 * 100;
+
+            using(MemoryStream stream = new MemoryStream(arraySize))
+            {
+                Serializer.SerializeWithLengthPrefix(stream, new Issue374TestModel(new byte[arraySize]), PrefixStyle.Base128);
+                bytes = stream.ToArray();
+            }
+
+            using(MemoryStream stream = new MemoryStream(bytes))
+            {
+                int fieldNumber = 0;
+                int bytesRead = 0;
+
+                ProtoReader.ReadLengthPrefix(stream, false, PrefixStyle.Base128, out fieldNumber, out bytesRead);
+
+                //These should be the same. They don't appear to be with the fault raised in issue 374
+                Assert.Equal(stream.Position, bytesRead);
+            }
+        }
+    }
+}

--- a/src/protobuf-net/ProtoReader.cs
+++ b/src/protobuf-net/ProtoReader.cs
@@ -1159,8 +1159,9 @@ namespace ProtoBuf
                 if (b < 0) throw EoF(null);
                 value |= ((ulong)b & 0x7F) << shift;
                 shift += 7;
+                bytesRead++;
 
-                if ((b & 0x80) == 0) return ++bytesRead;
+                if ((b & 0x80) == 0) return bytesRead;
             }
             b = source.ReadByte();
             if (b < 0) throw EoF(null);


### PR DESCRIPTION
This is the PR I mentioned that should address #374 assuming I was actually correct and that I am not just misunderstanding something. The issue describes why I think it was faulty and my reasoning.

Hopefully this is an acceptable PR if it was actually an issue! If it's not, let me know and I'll make the changes required to get this mergable.

There is a unit test covering that partially covers this addition called Issue374. It doesn't test every potential variant int result but it atleast covers a previously failing size. Which I hope is good enough.