### PR TITLE
Enable inlining of ProtoWriter.DemandSpace

### DIFF
--- a/src/protobuf-net/ProtoWriter.cs
+++ b/src/protobuf-net/ProtoWriter.cs
@@ -493,15 +493,22 @@ namespace ProtoBuf
             // check for enough space
             if ((writer.ioBuffer.Length - writer.ioIndex) < required)
             {
-                if (writer.flushLock == 0)
-                {
-                    Flush(writer); // try emptying the buffer
-                    if ((writer.ioBuffer.Length - writer.ioIndex) >= required) return;
-                }
-                // either can't empty the buffer, or that didn't help; need more space
-                BufferPool.ResizeAndFlushLeft(ref writer.ioBuffer, required + writer.ioIndex, 0, writer.ioIndex);
+                TryFlushOrResize(required, writer);
             }
         }
+
+        private static void TryFlushOrResize(int required, ProtoWriter writer)
+        {
+            if (writer.flushLock == 0)
+            {
+                Flush(writer); // try emptying the buffer
+                if ((writer.ioBuffer.Length - writer.ioIndex) >= required) return;
+            }
+
+            // either can't empty the buffer, or that didn't help; need more space
+            BufferPool.ResizeAndFlushLeft(ref writer.ioBuffer, required + writer.ioIndex, 0, writer.ioIndex);
+        }
+
         /// <summary>
         /// Flushes data to the underlying stream, and releases any resources. The underlying stream is *not* disposed
         /// by this operation.


### PR DESCRIPTION
ProtoWriter.DemandSpace is called in every Write* method and would profit from being inlined. Currently it is too big, but by extracting the less common path into a seperate method it can now be inlined (tested with RyuJIT on .Net Framework 4.7.1). The perf gain is actually more than I would have expected (~46ms instead of ~51ms for serializing 100 000 simple objects). Benchmark code can be found here: https://gist.github.com/szehetner/6c11a0545f0600c1c5ae5cd23527a1d2

The real world gain would probably be less as the benchmark code never needs to flush or resize, but should still be worthwile.