### PR TITLE
Allow value types to subclass from object #408

### DIFF
--- a/src/Examples/Issues/Issue408.cs
+++ b/src/Examples/Issues/Issue408.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
-using ProtoBuf.Meta;
+﻿using ProtoBuf.Meta;
 using Xunit;
 
 namespace ProtoBuf.Issues
 {
-    public class ValueTypeSubType
+    public class Issue408
     {
         public struct Point
         {
@@ -54,9 +51,7 @@ namespace ProtoBuf.Issues
             objectMetaType.AddSubType(1, typeof(Point));
 
             // This bug only occured in compiled type models
-            Directory.SetCurrentDirectory(@"C:\Users\Simon\Documents\GitHub\protobuf-net\src\protobuf-net\bin\Debug\net40");
-            var compiledTypeModel = model.Compile("test", "test.dll");
-            //var compiledTypeModel = Load(@"C:\Users\Simon\Documents\GitHub\protobuf-net\src\protobuf-net\bin\Debug\net40\test.dll");
+            var compiledTypeModel = model.Compile();
 
             var obj = new Point {X = 1, Y = 2};
             var clone = compiledTypeModel.DeepClone(obj);
@@ -66,22 +61,6 @@ namespace ProtoBuf.Issues
             var point = (Point) clone;
             Assert.Equal(1, point.X);
             Assert.Equal(2, point.Y);
-        }
-        
-        public static TypeModel Load(string assemblyFilePath)
-        {
-            var assembly = Assembly.LoadFrom(assemblyFilePath);
-            var types = assembly.GetTypes();
-            for(int i = 0; i < types.Length; ++i)
-            {
-                var type = types[i];
-                if (typeof(TypeModel).IsAssignableFrom(type))
-                {
-                    return (TypeModel)Activator.CreateInstance(type);
-                }
-            }
-            
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/protobuf-net.Test/Issues/ValueTypeSubType.cs
+++ b/src/protobuf-net.Test/Issues/ValueTypeSubType.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using ProtoBuf.Meta;
+using Xunit;
+
+namespace ProtoBuf.Issues
+{
+    public class ValueTypeSubType
+    {
+        public struct Point
+        {
+            public double X { get; set; }
+
+            public double Y { get; set; }
+        }
+
+        [Fact]
+        public void CanRoundtripValueTypeSubTypes()
+        {
+            var model = TypeModel.Create();
+
+            var objectMetaType = model.Add(typeof(object), false);
+
+            var metaType = model.Add(typeof(Point), false);
+            metaType.AddField(2, "X");
+            metaType.AddField(3, "Y");
+
+            objectMetaType.AddSubType(1, typeof(Point));
+
+            var obj = new Point {X = 1, Y = 2};
+            var clone = model.DeepClone(obj);
+            Assert.NotNull(clone);
+            Assert.IsType<Point>(clone);
+
+            var point = (Point) clone;
+            Assert.Equal(1, point.X);
+            Assert.Equal(2, point.Y);
+        }
+
+        [Fact]
+        public void CanRoundtripValueTypeSubTypesCompiled()
+        {
+            // https://github.com/mgravell/protobuf-net/issues/408
+
+            var model = TypeModel.Create();
+
+            var objectMetaType = model.Add(typeof(object), false);
+
+            var metaType = model.Add(typeof(Point), false);
+            metaType.AddField(2, "X");
+            metaType.AddField(3, "Y");
+
+            objectMetaType.AddSubType(1, typeof(Point));
+
+            // This bug only occured in compiled type models
+            Directory.SetCurrentDirectory(@"C:\Users\Simon\Documents\GitHub\protobuf-net\src\protobuf-net\bin\Debug\net40");
+            var compiledTypeModel = model.Compile("test", "test.dll");
+            //var compiledTypeModel = Load(@"C:\Users\Simon\Documents\GitHub\protobuf-net\src\protobuf-net\bin\Debug\net40\test.dll");
+
+            var obj = new Point {X = 1, Y = 2};
+            var clone = compiledTypeModel.DeepClone(obj);
+            Assert.NotNull(clone);
+            Assert.IsType<Point>(clone);
+
+            var point = (Point) clone;
+            Assert.Equal(1, point.X);
+            Assert.Equal(2, point.Y);
+        }
+        
+        public static TypeModel Load(string assemblyFilePath)
+        {
+            var assembly = Assembly.LoadFrom(assemblyFilePath);
+            var types = assembly.GetTypes();
+            for(int i = 0; i < types.Length; ++i)
+            {
+                var type = types[i];
+                if (typeof(TypeModel).IsAssignableFrom(type))
+                {
+                    return (TypeModel)Activator.CreateInstance(type);
+                }
+            }
+            
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/protobuf-net/Serializers/TypeSerializer.cs
+++ b/src/protobuf-net/Serializers/TypeSerializer.cs
@@ -367,6 +367,12 @@ namespace ProtoBuf.Serializers
                             ctx.DiscardValue();
                             ctx.Branch(nextTest, true);
                             ctx.MarkLabel(ifMatch);
+                            if (Helpers.IsValueType(serType))
+                            {
+                                ctx.DiscardValue();
+                                ctx.LoadValue(loc);
+                                ctx.CastFromObject(serType);
+                            }
                             ser.EmitWrite(ctx, null);
                             ctx.Branch(startFields, false);
                             ctx.MarkLabel(nextTest);
@@ -675,14 +681,44 @@ namespace ProtoBuf.Serializers
                     // nothing needs doing
                     ctx.MarkLabel(allDone);
                 }
-                ctx.LoadValue(loc);
-                ctx.Cast(serType);
+
+                if (Helpers.IsValueType(serType))
+                {
+                    Compiler.CodeLabel initValue = ctx.DefineLabel();
+                    Compiler.CodeLabel hasValue = ctx.DefineLabel();
+                    using (Compiler.Local emptyValue = new Compiler.Local(ctx, serType))
+                    {
+                        ctx.LoadValue(loc);
+                        ctx.BranchIfFalse(initValue, false);
+
+                        ctx.LoadValue(loc);
+                        ctx.CastFromObject(serType);
+                        ctx.Branch(hasValue, false);
+
+                        ctx.MarkLabel(initValue);
+                        ctx.InitLocal(serType, emptyValue);
+                        ctx.LoadValue(emptyValue);
+
+                        ctx.MarkLabel(hasValue);
+                    }
+                }
+                else
+                {
+                    ctx.LoadValue(loc);
+                    ctx.Cast(serType);
+                }
+
                 serializer.EmitRead(ctx, null);
                       
             }
             
             if (serializer.ReturnsValue)
             {   // update the variable
+                if (Helpers.IsValueType(serType))
+                {
+                    // but box it first in case of value type
+                    ctx.CastToObject(serType);
+                }
                 ctx.StoreValue(loc);
             }
             ctx.Branch(@continue, false); // "continue"


### PR DESCRIPTION
This PR addresses #408 in which bad IL was generated in case a value type is configured to inherit from System.Object. Both the generated ReadObject and WriteObject methods treated value types as if they were reference types (i.e. using castclass to cast an object into a value type instead of using unbox).

I plan on adding some more tests (passing null to Read/WriteObject instead of a boxed Point) tomorrow, but it's getting late here ;)

