### PR TITLE
Support IReadOnlyCollection members

### DIFF
--- a/src/protobuf-net.Test/Serializers/IReadOnlyCollectionTests.cs
+++ b/src/protobuf-net.Test/Serializers/IReadOnlyCollectionTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using ProtoBuf.Meta;
+using Xunit;
+
+namespace ProtoBuf.unittest.Serializers
+{
+    public class IReadOnlyCollectionTests
+    {
+        [Fact]
+        public void BasicIReadOnlyCollectionTest()
+        {
+            var orig = new TypeWithIReadOnlyCollection { Items = new List<string>{"abc", "def"} };
+            var model = TypeModel.Create();
+            var clone = (TypeWithIReadOnlyCollection)model.DeepClone(orig);
+            Assert.Equal(orig.Items, clone.Items); //, "Runtime");
+
+            model.CompileInPlace();
+            clone = (TypeWithIReadOnlyCollection)model.DeepClone(orig);
+            Assert.Equal(orig.Items, clone.Items); //, "CompileInPlace");
+
+            clone = (TypeWithIReadOnlyCollection)model.Compile().DeepClone(orig);
+            Assert.Equal(orig.Items, clone.Items); //, "Compile");
+        }
+
+        [ProtoContract]
+        public class TypeWithIReadOnlyCollection
+        {
+            [ProtoMember(1)]
+            public IReadOnlyCollection<string> Items { get; set; }
+        }
+    }
+}

--- a/src/protobuf-net/Meta/TypeModel.cs
+++ b/src/protobuf-net/Meta/TypeModel.cs
@@ -774,11 +774,11 @@ namespace ProtoBuf.Meta
             {   // fallback: look for ICollection<T>'s Add(typedObject) method
 
                 bool forceList = listTypeInfo.IsInterface &&
-                    listTypeInfo == model.MapType(typeof(System.Collections.Generic.IEnumerable<>)).MakeGenericType(types)
+                    model.MapType(typeof(System.Collections.Generic.IEnumerable<>)).MakeGenericType(types)
 #if WINRT || COREFX || PROFILE259
 					.GetTypeInfo()
 #endif
-                    ;
+                    .IsAssignableFrom(listTypeInfo);
 
 #if WINRT || COREFX || PROFILE259
 				TypeInfo constuctedListType = typeof(System.Collections.Generic.ICollection<>).MakeGenericType(types).GetTypeInfo();


### PR DESCRIPTION
ResolveIReadOnlyCollection now treats IReadOnlyCollection`  declared members as ImmutableCollection as well (previously only implementors of IReadOnlyCollection`)