### PR TITLE
Get full path of IntermediateOutputPath

### DIFF
--- a/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
+++ b/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
@@ -23,7 +23,7 @@
 		Condition="'@(ProtoDef)' != ''"
   >
     <PropertyGroup>
-      <ProtoCodeGenerationRoot>$(MSBuildProjectDirectory)\$(IntermediateOutputPath)</ProtoCodeGenerationRoot>
+      <ProtoCodeGenerationRoot>$([System.IO.Path]::GetFullPath($(IntermediateOutputPath)))</ProtoCodeGenerationRoot>
     </PropertyGroup>    
     
     <GenerateProtoBufCode

--- a/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
+++ b/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
@@ -23,7 +23,7 @@
 		Condition="'@(ProtoDef)' != ''"
   >
     <PropertyGroup>
-      <ProtoCodeGenerationRoot>$([System.IO.Path]::GetFullPath($(IntermediateOutputPath)))</ProtoCodeGenerationRoot>
+      <ProtoCodeGenerationRoot>$(IntermediateOutputPath)</ProtoCodeGenerationRoot>
     </PropertyGroup>    
     
     <GenerateProtoBufCode


### PR DESCRIPTION
Firstly, the work @MarkPflug did was amazing and I love that this is a feature!!

My only complaint is that this assumes `IntermediateOutputPath` is a relative path. If you're like me and develop in a container as well as a local machine, you'll have paths be absolute from a Directory.Build.props that [looks like this](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Directory.Build.props).

My only change is to not assume the path is relative, and just get the full path of where the `.cs` files are going. 

I managed to confirm the output is what this expects with a sample Target:
```xml
<Target Name="SomeLogs" BeforeTargets="GenerateProtoCode">
    <Message Text="Project Dir = $(MSBuildProjectDirectory)" Importance="high" />
    <Message Text="Intermediary Dir = $(IntermediateOutputPath)" Importance="high" />
    <Message Text="Intermediary Dir (Full Path) = $([System.IO.Path]::GetFullPath($(IntermediateOutputPath)))" Importance="high" />
</Target>
```

Without the `.props` mentioned above, the output is:
```
  Project Dir = /Users/rhartmann/src/saga-sample/src/Saga.Api
  Intermediary Dir = obj/Debug/netcoreapp2.1/
  Intermediary Dir (Full Path) = /Users/rhartmann/src/saga-sample/src/Saga.Api/obj/Debug/netcoreapp2.1/
```

With the file, the output is:
```
  Project Dir = /Users/rhartmann/src/saga-sample/src/Saga.Api
  Intermediary Dir = /Users/rhartmann/src/saga-sample/src/Saga.Api/obj/local/Debug/netcoreapp2.1/
  Intermediary Dir (Full Path) = /Users/rhartmann/src/saga-sample/src/Saga.Api/obj/local/Debug/netcoreapp2.1/
```