### PR TITLE
Span tweaks

### DIFF
--- a/src/protobuf-net/ProtoReader.ReadOnlySequence.cs
+++ b/src/protobuf-net/ProtoReader.ReadOnlySequence.cs
@@ -394,44 +394,44 @@ namespace ProtoBuf
 
             private int TryParseUInt32Varint(bool trimNegative, ReadOnlySpan<byte> span, int offset, out uint value)
             {
-                if (0 >= (uint)span.Length)
+                if (offset >= (uint)span.Length)
                 {
                     value = 0;
                     return 0;
                 }
 
-                value = span[0];
+                value = span[offset++];
                 if ((value & 0x80) == 0) return 1;
                 value &= 0x7F;
 
-                if (1 >= (uint)span.Length) ThrowEoF(this);
-                uint chunk = span[1];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                uint chunk = span[offset++];
                 value |= (chunk & 0x7F) << 7;
                 if ((chunk & 0x80) == 0) return 2;
 
-                if (2 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[2];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 14;
                 if ((chunk & 0x80) == 0) return 3;
 
-                if (3 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[3];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 21;
                 if ((chunk & 0x80) == 0) return 4;
 
-                if (4 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[4];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= chunk << 28; // can only use 4 bits from this chunk
                 if ((chunk & 0xF0) == 0) return 5;
 
                 if (trimNegative // allow for -ve values
                     && (chunk & 0xF0) == 0xF0
-                    && 9 < (uint)span.Length
-                        && span[5] == 0xFF
-                        && span[6] == 0xFF
-                        && span[7] == 0xFF
-                        && span[8] == 0xFF
-                        && span[9] == 0x01)
+                    && offset + 4 < (uint)span.Length
+                        && span[offset] == 0xFF
+                        && span[offset + 1] == 0xFF
+                        && span[offset + 2] == 0xFF
+                        && span[offset + 3] == 0xFF
+                        && span[offset + 4] == 0x01)
                 {
                     return 10;
                 }
@@ -441,57 +441,57 @@ namespace ProtoBuf
             }
             private int TryParseUInt64Varint(ReadOnlySpan<byte> span, int offset, out ulong value)
             {
-                if (0 >= (uint)span.Length)
+                if (offset >= (uint)span.Length)
                 {
                     value = 0;
                     return 0;
                 }
-                value = span[0];
+                value = span[offset++];
                 if ((value & 0x80) == 0) return 1;
                 value &= 0x7F;
 
-                if (1 >= (uint)span.Length) ThrowEoF(this);
-                ulong chunk = span[1];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                ulong chunk = span[offset++];
                 value |= (chunk & 0x7F) << 7;
                 if ((chunk & 0x80) == 0) return 2;
 
-                if (2 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[2];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 14;
                 if ((chunk & 0x80) == 0) return 3;
 
-                if (3 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[3];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 21;
                 if ((chunk & 0x80) == 0) return 4;
 
-                if (4 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[4];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 28;
                 if ((chunk & 0x80) == 0) return 5;
 
-                if (5 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[5];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 35;
                 if ((chunk & 0x80) == 0) return 6;
 
-                if (6 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[6];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 42;
                 if ((chunk & 0x80) == 0) return 7;
 
-                if (7 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[7];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 49;
                 if ((chunk & 0x80) == 0) return 8;
 
-                if (8 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[8];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset++];
                 value |= (chunk & 0x7F) << 56;
                 if ((chunk & 0x80) == 0) return 9;
 
-                if (9 >= (uint)span.Length) ThrowEoF(this);
-                chunk = span[9];
+                if (offset >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[offset];
                 value |= chunk << 63; // can only use 1 bit from this chunk
 
                 if ((chunk & ~(ulong)0x01) != 0) ThrowOverflow(this);

--- a/src/protobuf-net/ProtoReader.ReadOnlySequence.cs
+++ b/src/protobuf-net/ProtoReader.ReadOnlySequence.cs
@@ -88,7 +88,7 @@ namespace ProtoBuf
                 {
                     if (!_source.MoveNext())
                     {
-                        if (throwIfEOF) throw EoF(this);
+                        if (throwIfEOF) ThrowEoF(this);
                         return 0;
                     }
                     _current = _source.Current;
@@ -370,106 +370,107 @@ namespace ProtoBuf
             }
             private int TryParseUInt32Varint(bool trimNegative, ReadOnlySpan<byte> span, int offset, out uint value)
             {
-                var available = span.Length - offset;
-                if (available == 0)
+                if (0 >= (uint)span.Length)
                 {
                     value = 0;
                     return 0;
                 }
-                value = span[offset++];
+
+                value = span[0];
                 if ((value & 0x80) == 0) return 1;
                 value &= 0x7F;
-                if (available == 1) throw EoF(this);
 
-                uint chunk = span[offset++];
+                if (1 >= (uint)span.Length) ThrowEoF(this);
+                uint chunk = span[1];
                 value |= (chunk & 0x7F) << 7;
                 if ((chunk & 0x80) == 0) return 2;
-                if (available == 2) throw EoF(this);
 
-                chunk = span[offset++];
+                if (2 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[2];
                 value |= (chunk & 0x7F) << 14;
                 if ((chunk & 0x80) == 0) return 3;
-                if (available == 3) throw EoF(this);
 
-                chunk = span[offset++];
+                if (3 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[3];
                 value |= (chunk & 0x7F) << 21;
                 if ((chunk & 0x80) == 0) return 4;
-                if (available == 4) throw EoF(this);
 
-                chunk = span[offset];
+                if (4 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[4];
                 value |= chunk << 28; // can only use 4 bits from this chunk
                 if ((chunk & 0xF0) == 0) return 5;
 
                 if (trimNegative // allow for -ve values
                     && (chunk & 0xF0) == 0xF0
-                    && available >= 10
-                        && span[++offset] == 0xFF
-                        && span[++offset] == 0xFF
-                        && span[++offset] == 0xFF
-                        && span[++offset] == 0xFF
-                        && span[++offset] == 0x01)
+                    && 9 < (uint)span.Length
+                        && span[5] == 0xFF
+                        && span[6] == 0xFF
+                        && span[7] == 0xFF
+                        && span[8] == 0xFF
+                        && span[9] == 0x01)
                 {
                     return 10;
                 }
-                throw AddErrorData(new OverflowException(), this);
+
+                ThrowOverflow(this);
+                return 0;
             }
             private int TryParseUInt64Varint(ReadOnlySpan<byte> span, int offset, out ulong value)
             {
-                var available = span.Length - offset;
-                if (available == 0)
+                if (0 >= (uint)span.Length)
                 {
                     value = 0;
                     return 0;
                 }
-                value = span[offset++];
+                value = span[0];
                 if ((value & 0x80) == 0) return 1;
                 value &= 0x7F;
-                if (available == 1) throw EoF(this);
 
-                ulong chunk = span[offset++];
+                if (1 >= (uint)span.Length) ThrowEoF(this);
+                ulong chunk = span[1];
                 value |= (chunk & 0x7F) << 7;
                 if ((chunk & 0x80) == 0) return 2;
-                if (available == 2) throw EoF(this);
 
-                chunk = span[offset++];
+                if (2 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[2];
                 value |= (chunk & 0x7F) << 14;
                 if ((chunk & 0x80) == 0) return 3;
-                if (available == 3) throw EoF(this);
 
-                chunk = span[offset++];
+                if (3 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[3];
                 value |= (chunk & 0x7F) << 21;
                 if ((chunk & 0x80) == 0) return 4;
-                if (available == 4) throw EoF(this);
 
-                chunk = span[offset++];
+                if (4 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[4];
                 value |= (chunk & 0x7F) << 28;
                 if ((chunk & 0x80) == 0) return 5;
-                if (available == 5) throw EoF(this);
 
-                chunk = span[offset++];
+                if (5 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[5];
                 value |= (chunk & 0x7F) << 35;
                 if ((chunk & 0x80) == 0) return 6;
-                if (available == 6) throw EoF(this);
 
-                chunk = span[offset++];
+                if (6 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[6];
                 value |= (chunk & 0x7F) << 42;
                 if ((chunk & 0x80) == 0) return 7;
-                if (available == 7) throw EoF(this);
 
-                chunk = span[offset++];
+                if (7 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[7];
                 value |= (chunk & 0x7F) << 49;
                 if ((chunk & 0x80) == 0) return 8;
-                if (available == 8) throw EoF(this);
 
-                chunk = span[offset++];
+                if (8 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[8];
                 value |= (chunk & 0x7F) << 56;
                 if ((chunk & 0x80) == 0) return 9;
-                if (available == 9) throw EoF(this);
 
-                chunk = span[offset];
+                if (9 >= (uint)span.Length) ThrowEoF(this);
+                chunk = span[9];
                 value |= chunk << 63; // can only use 1 bit from this chunk
 
-                if ((chunk & ~(ulong)0x01) != 0) throw AddErrorData(new OverflowException(), this);
+                if ((chunk & ~(ulong)0x01) != 0) ThrowOverflow(this);
                 return 10;
             }
 

--- a/src/protobuf-net/ProtoReader.Stream.cs
+++ b/src/protobuf-net/ProtoReader.Stream.cs
@@ -150,22 +150,22 @@ namespace ProtoBuf
                 value = _ioBuffer[readPos++];
                 if ((value & 0x80) == 0) return 1;
                 value &= 0x7F;
-                if (_available == 1) throw EoF(this);
+                if (_available == 1) ThrowEoF(this);
 
                 uint chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 7;
                 if ((chunk & 0x80) == 0) return 2;
-                if (_available == 2) throw EoF(this);
+                if (_available == 2) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 14;
                 if ((chunk & 0x80) == 0) return 3;
-                if (_available == 3) throw EoF(this);
+                if (_available == 3) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 21;
                 if ((chunk & 0x80) == 0) return 4;
-                if (_available == 4) throw EoF(this);
+                if (_available == 4) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos];
                 value |= chunk << 28; // can only use 4 bits from this chunk
@@ -182,7 +182,8 @@ namespace ProtoBuf
                 {
                     return 10;
                 }
-                throw AddErrorData(new OverflowException(), this);
+                ThrowOverflow(this);
+                return 0;
             }
 
             private protected override ulong ImplReadUInt64Fixed(ref State state)
@@ -250,47 +251,47 @@ namespace ProtoBuf
                 value = _ioBuffer[readPos++];
                 if ((value & 0x80) == 0) return 1;
                 value &= 0x7F;
-                if (_available == 1) throw EoF(this);
+                if (_available == 1) ThrowEoF(this);
 
                 ulong chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 7;
                 if ((chunk & 0x80) == 0) return 2;
-                if (_available == 2) throw EoF(this);
+                if (_available == 2) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 14;
                 if ((chunk & 0x80) == 0) return 3;
-                if (_available == 3) throw EoF(this);
+                if (_available == 3) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 21;
                 if ((chunk & 0x80) == 0) return 4;
-                if (_available == 4) throw EoF(this);
+                if (_available == 4) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 28;
                 if ((chunk & 0x80) == 0) return 5;
-                if (_available == 5) throw EoF(this);
+                if (_available == 5) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 35;
                 if ((chunk & 0x80) == 0) return 6;
-                if (_available == 6) throw EoF(this);
+                if (_available == 6) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 42;
                 if ((chunk & 0x80) == 0) return 7;
-                if (_available == 7) throw EoF(this);
+                if (_available == 7) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 49;
                 if ((chunk & 0x80) == 0) return 8;
-                if (_available == 8) throw EoF(this);
+                if (_available == 8) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos++];
                 value |= (chunk & 0x7F) << 56;
                 if ((chunk & 0x80) == 0) return 9;
-                if (_available == 9) throw EoF(this);
+                if (_available == 9) ThrowEoF(this);
 
                 chunk = _ioBuffer[readPos];
                 value |= chunk << 63; // can only use 1 bit from this chunk
@@ -363,7 +364,7 @@ namespace ProtoBuf
                 }
                 if (strict && count > 0)
                 {
-                    throw EoF(this);
+                    ThrowEoF(this);
                 }
             }
 
@@ -405,7 +406,7 @@ namespace ProtoBuf
 
                 if (_isFixedLength)
                 {
-                    if (count > _dataRemaining64) throw EoF(this);
+                    if (count > _dataRemaining64) ThrowEoF(this);
                     // else assume we're going to be OK
                     _dataRemaining64 -= count;
                 }


### PR DESCRIPTION
* Remove double bounds checks (added by Jit), by checking `(uint)Span.Length` directly
* Reduce throw asm bulk to increase hot code, with void throwing methods
* Scope stackalloc to own methods (out of flow); so only zero-init'd when used