### PR TITLE
Speedups

### DIFF
--- a/src/protobuf-net/ProtoReader.ReadOnlySequence.cs
+++ b/src/protobuf-net/ProtoReader.ReadOnlySequence.cs
@@ -281,7 +281,7 @@ namespace ProtoBuf
                 if (GetSomeData(false) >= 10)
                 {
                     var span = Peek(out var offset);
-                    var read = TryParseUInt32Varint(mode == Read32VarintMode.Signed, span, offset, out value, this);
+                    var read = TryParseUInt32Varint(this, offset, mode == Read32VarintMode.Signed, out value, span);
                     Log($"T32 - {read}:{value}");
                     if (read != 0 && mode == Read32VarintMode.FieldHeader) ReadPreviewField(value, span, offset + read);
                     return read;
@@ -296,7 +296,7 @@ namespace ProtoBuf
                     Span<byte> span = stackalloc byte[20];
                     var available = ImplPeekBytes(span);
                     if (available != 20) span = span.Slice(0, available);
-                    var read = TryParseUInt32Varint(m == Read32VarintMode.Signed, span, 0, out val, this);
+                    var read = TryParseUInt32Varint(this, 0, m == Read32VarintMode.Signed, out val, span);
                     Log($"T32! - {read}:{val}");
                     if (read != 0 && m == Read32VarintMode.FieldHeader) ReadPreviewField(val, span, read);
                     return read;
@@ -338,7 +338,7 @@ namespace ProtoBuf
                         break;
                     case WireType.String:
                     case WireType.Variant:
-                        previewFieldBytes = TryParseUInt64Varint(span, offset, out previewField, this);
+                        previewFieldBytes = TryParseUInt64Varint(this, offset, out previewField, span);
                         Log($">RPF V64: {previewFieldBytes}: {previewField}");
                         break;
                     default:
@@ -369,7 +369,8 @@ namespace ProtoBuf
 
                 if (GetSomeData(false) >= 10)
                 {
-                    var read = TryParseUInt64Varint(Peek(out var offset), offset, out value, this);
+                    var span = Peek(out var offset);
+                    var read = TryParseUInt64Varint(this, offset, out value, span);
                     Log($"T64 - {read}:{value}");
                     return read;
                 }
@@ -383,13 +384,13 @@ namespace ProtoBuf
                     Span<byte> span = stackalloc byte[10];
                     var read = ImplPeekBytes(span);
                     if (read != 10) span = span.Slice(0, read);
-                    read = TryParseUInt64Varint(span, 0, out val, this);
+                    read = TryParseUInt64Varint(this, 0, out val, span);
                     Log($"T64! - {read}:{val}");
                     return read;
                 }
             }
 
-            internal static int TryParseUInt32Varint(bool trimNegative, ReadOnlySpan<byte> span, int offset, out uint value, ProtoReader @this)
+            internal static int TryParseUInt32Varint(ProtoReader @this, int offset, bool trimNegative, out uint value, ReadOnlySpan<byte> span)
             {
                 if ((uint)offset >= (uint)span.Length)
                 {
@@ -436,7 +437,7 @@ namespace ProtoBuf
                 ThrowOverflow(@this);
                 return 0;
             }
-            internal static int TryParseUInt64Varint(ReadOnlySpan<byte> span, int offset, out ulong value, ProtoReader @this)
+            internal static int TryParseUInt64Varint(ProtoReader @this, int offset, out ulong value, ReadOnlySpan<byte> span)
             {
                 if ((uint)offset >= (uint)span.Length)
                 {

--- a/src/protobuf-net/ProtoReader.StatefulReadOnlyMemoryProtoReader.cs
+++ b/src/protobuf-net/ProtoReader.StatefulReadOnlyMemoryProtoReader.cs
@@ -49,7 +49,7 @@ namespace ProtoBuf
             }
 
             private protected override int ImplTryReadUInt64VarintWithoutMoving(ref State state, out ulong value)
-                => ReadOnlySequenceProtoReader.TryParseUInt64Varint(Peek(in state, out var offset), offset, out value, this);
+                => ReadOnlySequenceProtoReader.TryParseUInt64Varint(this, state.OffsetInCurrent, out value, state.Span);
 
             private protected override uint ImplReadUInt32Fixed(ref State state)
                 => BinaryPrimitives.ReadUInt32LittleEndian(Consume(ref state, 4));
@@ -89,18 +89,11 @@ namespace ProtoBuf
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private ReadOnlySpan<byte> Peek(in State state, int bytes)
+            private ReadOnlySpan<byte> Peek(ref State state, int bytes)
                 => state.Span.Slice(state.OffsetInCurrent, bytes);
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private ReadOnlySpan<byte> Peek(in State state, out int offset)
-            {
-                offset = state.OffsetInCurrent;
-                return state.Span;
-            }
-
             private protected override int ImplTryReadUInt32VarintWithoutMoving(ref State state, Read32VarintMode mode, out uint value)
-                => ReadOnlySequenceProtoReader.TryParseUInt32Varint(mode == Read32VarintMode.Signed, Peek(in state, out var offset), offset, out value, this);
+                => ReadOnlySequenceProtoReader.TryParseUInt32Varint(this, state.OffsetInCurrent, mode == Read32VarintMode.Signed, out value, state.Span);
 
             private protected override void ImplSkipBytes(ref State state, long count, bool preservePreviewField)
             {


### PR DESCRIPTION
Stateful ROS on Core x 1.01

``` ini

BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17730
Intel Core i7-4720HQ CPU 2.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.300
  [Host] : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  Clr    : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3062.0
  Core   : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT

```
|         Method |  Job | Runtime |     Mean |     Error |    StdDev | Scaled | ScaledSD |    Gen 0 |   Gen 1 | Allocated |
|--------------- |----- |-------- |---------:|----------:|----------:|-------:|---------:|---------:|--------:|----------:|
|   MemoryStream |  Clr |     Clr | 2.178 ms | 0.0086 ms | 0.0076 ms |   1.00 |     0.00 | 148.4375 | 46.8750 | 734.82 KB |
|            ROS |  Clr |     Clr | 3.571 ms | 0.0105 ms | 0.0093 ms |   1.64 |     0.01 | 152.3438 | 50.7813 | 734.84 KB |
|   Stateful ROS |  Clr |     Clr | 2.761 ms | 0.0128 ms | 0.0120 ms |   1.27 |     0.01 | 144.5313 | 50.7813 | 734.74 KB |
|                |      |         |          |           |           |        |          |          |         |           |
|   MemoryStream | Core |    Core | 2.320 ms | 0.0142 ms | 0.0133 ms |   1.00 |     0.00 | 148.4375 | 46.8750 |  734.8 KB |
|            ROS | Core |    Core | 3.400 ms | 0.0435 ms | 0.0407 ms |   1.47 |     0.02 | 152.3438 | 50.7813 | 734.81 KB |
|   Stateful ROS | Core |    Core | 2.334 ms | 0.0402 ms | 0.0335 ms |   1.01 |     0.01 | 144.5313 | 50.7813 | 734.71 KB |