### PR TITLE
revert nerdbank versioning

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <VersionPrefix>2.3.18</VersionPrefix>
     <RootNamespace>ProtoBuf</RootNamespace>
     <Authors>Marc Gravell</Authors>
     <OutputType>Library</OutputType>
@@ -33,9 +34,11 @@
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="All" /> 
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.3" />
+	<!--
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.65">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+	-->
   </ItemGroup>
 </Project>

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.3.17",
+  "version": "2.3.18",
   "nugetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
Bumping version and reverting nerdbank versioning, the binding redirect is killing me..

[#442](https://github.com/mgravell/protobuf-net/issues/442)