### PR TITLE
Fix signed types being emitted for fixed32 and fixed64

### DIFF
--- a/src/protobuf-net.Reflection/CodeGenerator.OneOfStub.cs
+++ b/src/protobuf-net.Reflection/CodeGenerator.OneOfStub.cs
@@ -82,20 +82,20 @@ namespace ProtoBuf.Reflection
                     case FieldDescriptorProto.Type.TypeInt32:
                     case FieldDescriptorProto.Type.TypeSfixed32:
                     case FieldDescriptorProto.Type.TypeSint32:
-                    case FieldDescriptorProto.Type.TypeFixed32:
                     case FieldDescriptorProto.Type.TypeEnum:
                         return "Int32";
                     case FieldDescriptorProto.Type.TypeFloat:
                         return "Single";
+                    case FieldDescriptorProto.Type.TypeFixed32:
                     case FieldDescriptorProto.Type.TypeUint32:
                         return "UInt32";
                     case FieldDescriptorProto.Type.TypeDouble:
                         return "Double";
-                    case FieldDescriptorProto.Type.TypeFixed64:
                     case FieldDescriptorProto.Type.TypeInt64:
                     case FieldDescriptorProto.Type.TypeSfixed64:
                     case FieldDescriptorProto.Type.TypeSint64:
                         return "Int64";
+                    case FieldDescriptorProto.Type.TypeFixed64:
                     case FieldDescriptorProto.Type.TypeUint64:
                         return "UInt64";
                     case FieldDescriptorProto.Type.TypeMessage:


### PR DESCRIPTION
This fixed a bug where it generates the following line:
```csharp
get { return __pbn__ip.Is(1) ? __pbn__ip.Int32 : default(uint); }
```

And it ends up failing ot compile:
> Type of conditional expression cannot be determined because there is no implicit conversion between 'int' and 'uint'

Which mismatches the type generated here:

https://github.com/mgravell/protobuf-net/blob/2016a3edb9cdc9efa92330dc0a03ebf09ec5c024/src/protobuf-net.Reflection/CSharpCodeGenerator.cs#L808-L810

https://github.com/mgravell/protobuf-net/blob/2016a3edb9cdc9efa92330dc0a03ebf09ec5c024/src/protobuf-net.Reflection/CSharpCodeGenerator.cs#L813-L815