### PR TITLE
Return early if codegen is null

### DIFF
--- a/src/protogen/Program.cs
+++ b/src/protogen/Program.cs
@@ -213,6 +213,8 @@ namespace protogen
                         {
                             Serializer.Serialize(fds, set);
                         }
+                        
+                        return 0;
                     }
                     
                     


### PR DESCRIPTION
I'm not sure what the correct behaviour here is, but if `codegen` is null, it will crash on `codegen.Generate` below.