### PR TITLE
Fix for Issue #499 where the buffer pool uses the wrong index

### DIFF
--- a/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
+++ b/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Xunit;
+
+namespace ProtoBuf.Issues
+{
+    public class BufferPoolUsesIncorrectIndex
+    {
+        [Fact]
+        public void ReleaseBufferToPoolUsesCorrectIndexWithFreeSlot()
+        {
+            byte[][] possiblyFromThePool = new byte[BufferPool.POOL_SIZE][];
+            // Since the BufferPool is static lets empty it by requesting BufferPool.POOL_SIZE buffers
+            for (int i = 0; i < BufferPool.POOL_SIZE; i++)
+            {
+                possiblyFromThePool[i] = BufferPool.GetBuffer();
+            }
+
+            // Make sure GC doesn't run while we do.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            var firstBuffer = BufferPool.GetBuffer();
+            // Make a copy so we keep our weak reference around
+            var firstBufferCopy = firstBuffer;
+            firstBuffer[0] = 1;
+            var secondBuffer = BufferPool.GetBuffer();
+            secondBuffer[0] = 2;
+            var secondBufferCopy = secondBuffer;
+            BufferPool.ReleaseBufferToPool(ref firstBuffer);
+            BufferPool.ReleaseBufferToPool(ref secondBuffer);
+            // Now the pool should have two weak references.
+            // but in our bug case only the first pool item will be filled.
+            var firstReusedBuffer = BufferPool.GetBuffer();
+            var secondReusedBuffer = BufferPool.GetBuffer();
+            // Now the first buffer should be one of reused ones.
+            // As reused buffers won't be set to zero by the runtime.
+            Assert.NotEqual(0, firstReusedBuffer[0]);
+            // As should the second buffer.
+            Assert.NotEqual(0, secondReusedBuffer[0]);
+        }
+    }
+}

--- a/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
+++ b/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace ProtoBuf.Issues
 {
@@ -8,13 +7,9 @@ namespace ProtoBuf.Issues
         [Fact]
         public void ReleaseBufferToPoolUsesCorrectIndexWithFreeSlot()
         {
-            byte[][] possiblyFromThePool = new byte[BufferPool.POOL_SIZE][];
-            // Since the BufferPool is static lets empty it by requesting BufferPool.POOL_SIZE buffers
-            for (int i = 0; i < BufferPool.POOL_SIZE; i++)
-            {
-                possiblyFromThePool[i] = BufferPool.GetBuffer();
-            }
-
+            // Since the BufferPool is static flush it.
+            BufferPool.Flush();
+            // Get a buffer
             var firstBuffer = BufferPool.GetBuffer();
             // Make a copy so we keep our weak reference around
             var firstBufferCopy = firstBuffer;

--- a/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
+++ b/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
@@ -11,7 +11,7 @@ namespace ProtoBuf.Issues
             BufferPool.Flush();
             // Get a buffer
             var firstBuffer = BufferPool.GetBuffer();
-            // Make a copy so we keep our weak reference around
+            // Make a copy so we keep our weak references around
             var firstBufferCopy = firstBuffer;
             firstBuffer[0] = 1;
             var secondBuffer = BufferPool.GetBuffer();
@@ -19,15 +19,15 @@ namespace ProtoBuf.Issues
             var secondBufferCopy = secondBuffer;
             BufferPool.ReleaseBufferToPool(ref firstBuffer);
             BufferPool.ReleaseBufferToPool(ref secondBuffer);
-            // Now the pool should have two weak references.
+            // Now the pool would have two CachedBuffers.
             // but in our bug case only the first pool item will be filled.
             var firstReusedBuffer = BufferPool.GetBuffer();
             var secondReusedBuffer = BufferPool.GetBuffer();
             // Now the first buffer should be one of reused ones.
-            // Reused buffers won't be set to zero by the runtime.
-            Assert.NotEqual(0, firstReusedBuffer[0]);
+            // Also checking this way should keep our copies alive.
+            Assert.True(firstReusedBuffer[0] == firstBufferCopy[0] || firstReusedBuffer[0] == secondBufferCopy[0]);
             // As should the second buffer.
-            Assert.NotEqual(0, secondReusedBuffer[0]);
+            Assert.True(secondReusedBuffer[0] == firstBufferCopy[0] || secondReusedBuffer[0] == secondBufferCopy[0]);
         }
     }
 }

--- a/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
+++ b/src/protobuf-net.Test/Issues/BufferPoolUsesIncorrectIndex.cs
@@ -15,11 +15,6 @@ namespace ProtoBuf.Issues
                 possiblyFromThePool[i] = BufferPool.GetBuffer();
             }
 
-            // Make sure GC doesn't run while we do.
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
             var firstBuffer = BufferPool.GetBuffer();
             // Make a copy so we keep our weak reference around
             var firstBufferCopy = firstBuffer;
@@ -34,7 +29,7 @@ namespace ProtoBuf.Issues
             var firstReusedBuffer = BufferPool.GetBuffer();
             var secondReusedBuffer = BufferPool.GetBuffer();
             // Now the first buffer should be one of reused ones.
-            // As reused buffers won't be set to zero by the runtime.
+            // Reused buffers won't be set to zero by the runtime.
             Assert.NotEqual(0, firstReusedBuffer[0]);
             // As should the second buffer.
             Assert.NotEqual(0, secondReusedBuffer[0]);

--- a/src/protobuf-net/BufferPool.cs
+++ b/src/protobuf-net/BufferPool.cs
@@ -14,7 +14,7 @@ namespace ProtoBuf
         }
 
         private BufferPool() { }
-        private const int POOL_SIZE = 20;
+        internal const int POOL_SIZE = 20;
         internal const int BUFFER_LENGTH = 1024;
         private static readonly CachedBuffer[] Pool = new CachedBuffer[POOL_SIZE];
 
@@ -114,7 +114,7 @@ namespace ProtoBuf
                     var tmp = Pool[i];
                     if (tmp == null || !tmp.IsAlive)
                     {
-                        minIndex = 0;
+                        minIndex = i;
                         break;
                     }
                     if (tmp.Size < minSize)

--- a/src/protobuf-net/BufferPool.cs
+++ b/src/protobuf-net/BufferPool.cs
@@ -14,7 +14,7 @@ namespace ProtoBuf
         }
 
         private BufferPool() { }
-        internal const int POOL_SIZE = 20;
+        private const int POOL_SIZE = 20;
         internal const int BUFFER_LENGTH = 1024;
         private static readonly CachedBuffer[] Pool = new CachedBuffer[POOL_SIZE];
 


### PR DESCRIPTION
Fix for a bug where the buffer pool always ends up the zeroth entry in the pool when returning items to the pool.
Found this while looking into putting back the interlock compare and exchange.