### PR TITLE
Add a protogen name normalizer without pluralization

### DIFF
--- a/src/protobuf-net.Reflection/CodeGenerator.cs
+++ b/src/protobuf-net.Reflection/CodeGenerator.cs
@@ -473,6 +473,7 @@ namespace ProtoBuf.Reflection
                     if (nn != null) nn = nn.Trim();
                     if (string.Equals(nn, "auto", StringComparison.OrdinalIgnoreCase)) nameNormalizer = NameNormalizer.Default;
                     else if (string.Equals(nn, "original", StringComparison.OrdinalIgnoreCase)) nameNormalizer = NameNormalizer.Null;
+                    else if (string.Equals(nn, "noplural", StringComparison.OrdinalIgnoreCase)) nameNormalizer = NameNormalizer.NoPlural;
                 }
 
                 string langver = null;

--- a/src/protobuf-net.Reflection/NameNormalizer.cs
+++ b/src/protobuf-net.Reflection/NameNormalizer.cs
@@ -49,6 +49,14 @@ namespace ProtoBuf.Reflection
             /// </summary>
             public override string Pluralize(string identifier) => AutoPluralize(identifier);
         }
+        private class NoPluralNormalizer : NameNormalizer
+        {
+            protected override string GetName(string identifier) => AutoCapitalize(identifier);
+            /// <summary>
+            /// Suggest a name with idiomatic pluralization
+            /// </summary>
+            public override string Pluralize(string identifier) => identifier;
+        }
         /// <summary>
         /// Suggest a name with idiomatic name capitalization
         /// </summary>
@@ -108,6 +116,10 @@ namespace ProtoBuf.Reflection
         /// Name normalizer that passes through all identifiers without any changes
         /// </summary>
         public static NameNormalizer Null => new NullNormalizer(); // intentionally not reused
+        /// <summary>
+        /// Name normalizer with default protobuf-net behaviour, using .NET idioms, without pluralization
+        /// </summary>
+        public static NameNormalizer NoPlural => new NoPluralNormalizer(); // intentionally not reused
         /// <summary>
         /// Suggest a normalized identifier
         /// </summary>

--- a/src/protogen/Program.cs
+++ b/src/protogen/Program.cs
@@ -307,7 +307,8 @@ Parse PROTO_FILES and generate output based on the options given:
   --vb_out=OUT_DIR            Generate VB source file(s).
   +langver=VERSION            Request a specific language version from the
                               selected code generator.
-  +names={auto|original}      Specify naming convention rules.
+  +names={auto|original|noplural}
+                              Specify naming convention rules.
   +oneof={default|enum}       Specify whether 'oneof' should generate enums.
   +listset={yes|no}           Specify whether lists should emit setters
   +OPTION=VALUE               Specify a custom OPTION/VALUE pair for the


### PR DESCRIPTION
This patch provides a third option to protogen name normalization that still uses C# style but does not attempt to automatically pluralize names.