### PR TITLE
Add trap for invalid serialization callbacks.

### DIFF
--- a/src/protobuf-net/Serializers/TypeSerializer.cs
+++ b/src/protobuf-net/Serializers/TypeSerializer.cs
@@ -76,7 +76,17 @@ namespace ProtoBuf.Serializers
             this.isRootType = isRootType;
             this.useConstructor = useConstructor;
 
-            if (baseCtorCallbacks != null && baseCtorCallbacks.Length == 0) baseCtorCallbacks = null;
+            if(baseCtorCallbacks != null)
+            {
+                foreach(var cb in baseCtorCallbacks)
+                {
+                    if(!cb.ReflectedType.IsAssignableFrom(forType))
+                        throw new InvalidOperationException("Trying to assign incompatible callback to " + forType.FullName);
+                }
+                if(baseCtorCallbacks.Length == 0)
+                    baseCtorCallbacks = null;
+            }
+
             this.baseCtorCallbacks = baseCtorCallbacks;
 
             if (Helpers.GetUnderlyingType(forType) != null)


### PR DESCRIPTION
Using IL-compiled ProtoReader/Writer hides invalid callback assignment
that causes heap corruption if adding derived type MethodInfo callback
to base or sibling type via MetaType.SetCallbacks() for RuntimeTypeModel.

This patch throws an exception if this scenario is detected.